### PR TITLE
feat: rest timer alignment, auto-add set on completion, slide animation

### DIFF
--- a/src/domains/fitness/hooks/useSet.ts
+++ b/src/domains/fitness/hooks/useSet.ts
@@ -22,6 +22,7 @@ interface UseSetProps {
     isStatic: boolean;
     previousPerformance: { weight: number; reps: number | null; time_seconds?: number | null; distance_km?: number | null } | null;
     recommendedPerformance: RecommendedStrengthSetPerformance | null;
+    onComplete?: () => void;
 }
 
 type StrengthSetUpdatePayload = {
@@ -40,7 +41,8 @@ export const useSet = ({
     userBodyweight,
     isStatic,
     previousPerformance,
-    recommendedPerformance
+    recommendedPerformance,
+    onComplete,
 }: UseSetProps) => {
     const dispatch = useAppDispatch();
 
@@ -247,6 +249,7 @@ export const useSet = ({
                     }
                 }
                 dispatch(completeSetAction({ workoutExerciseId, setId: set.id, completed: true }));
+                onComplete?.();
             } else {
                 dispatch(completeSetAction({ workoutExerciseId, setId: set.id, completed: false }));
             }
@@ -274,6 +277,7 @@ export const useSet = ({
                         distance_km: distanceVal > 0 ? distanceVal : undefined,
                     }));
                     dispatch(completeSetAction({ workoutExerciseId, setId: set.id, completed: true }));
+                    onComplete?.();
                 } else {
                     setIsCompleted(false);
                 }
@@ -281,7 +285,7 @@ export const useSet = ({
                 dispatch(completeSetAction({ workoutExerciseId, setId: set.id, completed: false }));
             }
         }
-    }, [dispatch, workoutExerciseId, set, isStatic, localWeight, localReps, localTime, localDuration, localDistance, previousPerformance]);
+    }, [dispatch, workoutExerciseId, set, isStatic, localWeight, localReps, localTime, localDuration, localDistance, previousPerformance, onComplete]);
 
     const handleBlur = useCallback((field: 'weight' | 'reps' | 'time' | 'duration' | 'distance') => {
         if (isCompleted) return;

--- a/src/domains/fitness/ui/SetComponent.tsx
+++ b/src/domains/fitness/ui/SetComponent.tsx
@@ -24,6 +24,7 @@ interface SetComponentProps extends MotionProps {
   userBodyweight?: number | null;
   isStatic: boolean;
   isActive?: boolean;
+  onComplete?: () => void;
 }
 
 const SetComponent: React.FC<SetComponentProps> = ({
@@ -35,6 +36,7 @@ const SetComponent: React.FC<SetComponentProps> = ({
   userBodyweight,
   isStatic,
   isActive = false,
+  onComplete,
   ...motionProps
 }) => {
   const {
@@ -63,7 +65,8 @@ const SetComponent: React.FC<SetComponentProps> = ({
     userBodyweight,
     isStatic,
     previousPerformance,
-    recommendedPerformance
+    recommendedPerformance,
+    onComplete,
   });
   const weightIndicatorDirection =
     recommendedPerformance?.action === 'increase_load'

--- a/src/domains/fitness/ui/WorkoutExerciseView.tsx
+++ b/src/domains/fitness/ui/WorkoutExerciseView.tsx
@@ -639,7 +639,7 @@ export const WorkoutExerciseView = ({
               <CardioZoneIndicator sessionFocus={sessionFocus} />
             )}
 
-            <div className="relative">
+            <div>
               <div className="stone-surface overflow-hidden rounded-[18px]">
                 <Table className="w-full">
                   <TableHeader className="stone-table-head">
@@ -680,10 +680,11 @@ export const WorkoutExerciseView = ({
                             userBodyweight={userBodyweight}
                             isStatic={isExerciseStatic}
                             isActive={firstIncompleteSetIndex === -1 ? index === workoutExercise.sets.length - 1 : index === firstIncompleteSetIndex}
-                            initial={{ opacity: 0, height: 0 }}
-                            animate={{ opacity: 1, height: 'auto' }}
+                            onComplete={onAddSet}
+                            initial={{ opacity: 0, height: 0, y: 16 }}
+                            animate={{ opacity: 1, height: 'auto', y: 0 }}
                             exit={{ opacity: 0, height: 0 }}
-                            transition={{ type: 'tween', duration: 0.5 }}
+                            transition={{ type: 'spring', stiffness: 380, damping: 30 }}
                             layout
                           />
                         );
@@ -791,18 +792,18 @@ export const WorkoutExerciseView = ({
                           </>
                         )}
 
-                        <TableCell className="px-0 py-3 align-middle"></TableCell>
+                        <TableCell className="px-0 py-3 align-middle">
+                          {restStartTime && (
+                            <div className="flex items-center justify-center">
+                              <RestTimer startTime={restStartTime} />
+                            </div>
+                          )}
+                        </TableCell>
                       </motion.tr>
                     </AnimatePresence>
                   </TableBody>
                 </Table>
               </div>
-              {restStartTime && (
-                <RestTimer
-                  startTime={restStartTime}
-                  className="absolute bottom-2.5 right-3 pointer-events-none"
-                />
-              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
- Move RestTimer from absolute bottom-right position into the last table cell
  of the add-set row so it aligns pixel-perfect with the SwipeableIncrementer
  components (same row, same table cell structure)
- Auto-add a new set when completing a set by passing onAddSet as onComplete
  callback through SetComponent into useSet, firing after successful dispatch
- Change set entry animation to spring physics with y:16 slide-from-bottom
  for a smooth slide-up effect as new sets appear

https://claude.ai/code/session_01139MEe3ATHJ9AQgTcedN9J