### PR TITLE
Show exercise variation and equipment in analytics workout history

### DIFF
--- a/src/domains/analytics/data/analyticsRepository.ts
+++ b/src/domains/analytics/data/analyticsRepository.ts
@@ -42,6 +42,8 @@ export interface WorkoutSet {
 export interface WorkoutExerciseDetail {
     exercise_id: string;
     exercise_name: string;
+    variation: string | null;
+    equipment_type: string | null;
     order: number;
     sets: WorkoutSet[];
     completed_sets_count: number;
@@ -108,6 +110,8 @@ interface LatestMaxRepsRow {
 type DetailedWorkoutExerciseRow = {
     exercise_id: string;
     order: number;
+    variation: string | null;
+    equipment_type: string | null;
     exercises: NestedRelationship<{ name: string | null }>;
     exercise_sets: WorkoutSet[] | null;
 };
@@ -377,6 +381,8 @@ export const fetchDetailedWorkoutById = async (userId: string, workoutId: string
         .select(`
         exercise_id,
         order,
+        variation,
+        equipment_type,
         exercises ( name ),
         exercise_sets ( set_number, reps, weight, time_seconds, completed )
       `)
@@ -399,6 +405,8 @@ export const fetchDetailedWorkoutById = async (userId: string, workoutId: string
         return {
             exercise_id: we.exercise_id,
             exercise_name: exercise?.name || 'Unknown Exercise',
+            variation: we.variation ?? null,
+            equipment_type: we.equipment_type ?? null,
             order: we.order,
             sets: sets,
             completed_sets_count: sets.filter((s: WorkoutSet) => s.completed).length,

--- a/src/domains/analytics/ui/RecentWorkouts.tsx
+++ b/src/domains/analytics/ui/RecentWorkouts.tsx
@@ -28,6 +28,16 @@ const formatDate = (dateInput: string): string => {
     }
 };
 
+const formatVariation = (variation: string | null): string => {
+    if (!variation) return 'Standard';
+    return variation;
+};
+
+const formatEquipment = (equipmentType: string | null): string => {
+    if (!equipmentType) return 'Bodyweight';
+    return equipmentType;
+};
+
 const RecentWorkoutsView: React.FC<{ userId: string | undefined }> = ({ userId }) => {
     const {
         recentWorkouts,
@@ -142,6 +152,9 @@ const RecentWorkoutsView: React.FC<{ userId: string | undefined }> = ({ userId }
                             {detailedWorkout.exercises.length > 0 ? detailedWorkout.exercises.map(exercise => (
                                 <div key={exercise.exercise_id} className="stone-surface rounded-[18px] p-4">
                                     <h4 className="mb-1.5 text-base font-semibold text-foreground">{exercise.exercise_name}</h4>
+                                    <p className="mb-1 text-xs text-muted-foreground">
+                                        Variation: {formatVariation(exercise.variation)} · Equipment: {formatEquipment(exercise.equipment_type)}
+                                    </p>
                                     <p className="mb-2 text-xs text-muted-foreground">
                                         {exercise.completed_sets_count} completed set{exercise.completed_sets_count !== 1 ? 's' : ''}
                                     </p>


### PR DESCRIPTION
### Motivation

- Provide richer workout history details by surfacing exercise `variation` and `equipment_type` alongside existing sets/reps/weight information so users can see how an exercise was performed.

### Description

- Added `variation` and `equipment_type` to the `WorkoutExerciseDetail` model and `DetailedWorkoutExerciseRow` typing in `src/domains/analytics/data/analyticsRepository.ts`.
- Included `variation` and `equipment_type` in the Supabase `.select()` for `workout_exercises` and mapped those fields into the returned `DetailedWorkout` payload.
- Updated `src/domains/analytics/ui/RecentWorkouts.tsx` to render variation and equipment for each exercise with fallback labels `Standard` and `Bodyweight` via small formatter helpers.

### Testing

- Built the app with `npm run build` and the build completed successfully.
- Ran lint with `npm run lint` and it completed with the existing baseline warnings (8 warnings) and no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcbd4f5540832cb3220bef170f2e02)