### PR TITLE
Show exercise variation and equipment in detailed workout view and include in data model

### DIFF
--- a/src/domains/analytics/data/analyticsRepository.ts
+++ b/src/domains/analytics/data/analyticsRepository.ts
@@ -42,6 +42,8 @@ export interface WorkoutSet {
 export interface WorkoutExerciseDetail {
     exercise_id: string;
     exercise_name: string;
+    variation: string | null;
+    equipment_type: string | null;
     order: number;
     sets: WorkoutSet[];
     completed_sets_count: number;
@@ -108,6 +110,8 @@ interface LatestMaxRepsRow {
 type DetailedWorkoutExerciseRow = {
     exercise_id: string;
     order: number;
+    variation: string | null;
+    equipment_type: string | null;
     exercises: NestedRelationship<{ name: string | null }>;
     exercise_sets: WorkoutSet[] | null;
 };
@@ -377,6 +381,8 @@ export const fetchDetailedWorkoutById = async (userId: string, workoutId: string
         .select(`
         exercise_id,
         order,
+        variation,
+        equipment_type,
         exercises ( name ),
         exercise_sets ( set_number, reps, weight, time_seconds, completed )
       `)
@@ -399,6 +405,8 @@ export const fetchDetailedWorkoutById = async (userId: string, workoutId: string
         return {
             exercise_id: we.exercise_id,
             exercise_name: exercise?.name || 'Unknown Exercise',
+            variation: we.variation ?? null,
+            equipment_type: we.equipment_type ?? null,
             order: we.order,
             sets: sets,
             completed_sets_count: sets.filter((s: WorkoutSet) => s.completed).length,

--- a/src/domains/analytics/ui/RecentWorkouts.tsx
+++ b/src/domains/analytics/ui/RecentWorkouts.tsx
@@ -28,6 +28,16 @@ const formatDate = (dateInput: string): string => {
     }
 };
 
+const formatVariation = (variation: string | null): string => {
+    if (!variation) return 'Unspecified';
+    return variation.toLowerCase() === 'standard' ? 'Standard' : variation;
+};
+
+const formatEquipment = (equipmentType: string | null): string => {
+    if (!equipmentType) return 'Unspecified';
+    return equipmentType;
+};
+
 const RecentWorkoutsView: React.FC<{ userId: string | undefined }> = ({ userId }) => {
     const {
         recentWorkouts,
@@ -140,8 +150,14 @@ const RecentWorkoutsView: React.FC<{ userId: string | undefined }> = ({ userId }
                     {!isLoadingDetailedWorkout && !errorDetailedWorkout && detailedWorkout && (
                         <div className="mt-4 space-y-4">
                             {detailedWorkout.exercises.length > 0 ? detailedWorkout.exercises.map(exercise => (
-                                <div key={exercise.exercise_id} className="stone-surface rounded-[18px] p-4">
+                                <div
+                                    key={`${exercise.exercise_id}-${exercise.order}-${exercise.variation ?? 'unspecified'}-${exercise.equipment_type ?? 'unspecified'}`}
+                                    className="stone-surface rounded-[18px] p-4"
+                                >
                                     <h4 className="mb-1.5 text-base font-semibold text-foreground">{exercise.exercise_name}</h4>
+                                    <p className="mb-1 text-xs text-muted-foreground">
+                                        Variation Type: {formatVariation(exercise.variation)} · Equipment Type: {formatEquipment(exercise.equipment_type)}
+                                    </p>
                                     <p className="mb-2 text-xs text-muted-foreground">
                                         {exercise.completed_sets_count} completed set{exercise.completed_sets_count !== 1 ? 's' : ''}
                                     </p>


### PR DESCRIPTION
### Motivation
- Surface exercise `variation` and `equipment_type` in the detailed workout view so users can see which variation/equipment was used for each exercise. 
- Persist these fields through the data layer to ensure accurate rendering and unique list keys when multiple variations of the same exercise exist. 

### Description
- Extended the analytics data model to include `variation` and `equipment_type` in `WorkoutExerciseDetail` and the DB row type `DetailedWorkoutExerciseRow`. 
- Updated `fetchDetailedWorkoutById` to select `variation` and `equipment_type` from `workout_exercises` and to map those values into the returned `DetailedWorkout` object. 
- Updated the `RecentWorkouts` UI (`RecentWorkouts.tsx`) to format and display `Variation Type` and `Equipment Type` for each exercise, add helper formatters `formatVariation` and `formatEquipment`, and use a composite React key that includes `variation` and `equipment_type` to avoid key collisions. 

### Testing
- Ran TypeScript typecheck (`tsc`) to validate type changes and it succeeded. 
- Executed the existing automated unit tests (`npm test`) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcbd4f5540832cb3220bef170f2e02)