### PR TITLE
Harden lazy route loading in MainAppLayout

### DIFF
--- a/src/components/layout/MainAppLayout.tsx
+++ b/src/components/layout/MainAppLayout.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy } from "react";
+import { Component, Suspense, lazy, type ReactNode } from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
 import { Plus } from "lucide-react";
 
@@ -15,19 +15,58 @@ import { SidebarInset, SidebarProvider } from "@/components/core/sidebar";
 import { useOfflineWorkoutSync } from "@/domains/fitness/hooks/useOfflineWorkoutSync";
 import { useQuickActions } from "@/domains/fitness/hooks/useQuickActions";
 
-const AddSingleExerciseDialog = lazy(
+const lazyWithRetry = <TModule extends { default: React.ComponentType<unknown> }>(
+  importFn: () => Promise<TModule>
+) =>
+  lazy(async () => {
+    try {
+      return await importFn();
+    } catch (error) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      return importFn();
+    }
+  });
+
+class RouteErrorBoundary extends Component<
+  { children: ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="app-page">
+          <div className="stone-surface rounded-[26px] p-6 text-sm text-muted-foreground">
+            We couldn&apos;t load this screen yet. Please try again.
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const AddSingleExerciseDialog = lazyWithRetry(
   () => import("@/domains/fitness/ui/AddSingleExerciseDialog")
 );
-const ProteinLogging = lazy(() => import("@/domains/fitness/ui/ProteinLogging"));
-const SunExposureLogging = lazy(
+const ProteinLogging = lazyWithRetry(
+  () => import("@/domains/fitness/ui/ProteinLogging")
+);
+const SunExposureLogging = lazyWithRetry(
   () => import("@/domains/fitness/ui/SunExposureLogging")
 );
-const Home = lazy(() => import("@/pages/Home"));
-const Workout = lazy(() => import("@/pages/Workout"));
-const Analytics = lazy(() => import("@/pages/Analytics"));
-const Coach = lazy(() => import("@/pages/Coach"));
-const Settings = lazy(() => import("@/pages/Settings"));
-const NotFound = lazy(() => import("@/pages/NotFound"));
+const Home = lazyWithRetry(() => import("@/pages/Home"));
+const Workout = lazyWithRetry(() => import("@/pages/Workout"));
+const Analytics = lazyWithRetry(() => import("@/pages/Analytics"));
+const Coach = lazyWithRetry(() => import("@/pages/Coach"));
+const Settings = lazyWithRetry(() => import("@/pages/Settings"));
+const NotFound = lazyWithRetry(() => import("@/pages/NotFound"));
 
 const RouteFallback = () => (
   <div className="app-page">
@@ -67,16 +106,18 @@ const MainAppLayout = () => {
         <NavBar />
       </div>
       <SidebarInset className="app-shell">
-        <Suspense fallback={<RouteFallback />}>
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/workout" element={<Workout />} />
-            <Route path="/analytics" element={<Analytics />} />
-            <Route path="/coach" element={<Coach />} />
-            <Route path="/settings" element={<Settings />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </Suspense>
+        <RouteErrorBoundary>
+          <Suspense fallback={<RouteFallback />}>
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/workout" element={<Workout />} />
+              <Route path="/analytics" element={<Analytics />} />
+              <Route path="/coach" element={<Coach />} />
+              <Route path="/settings" element={<Settings />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </Suspense>
+        </RouteErrorBoundary>
 
         {shouldShowGlobalFab && (
           <div className="fixed bottom-20 right-6 z-20">


### PR DESCRIPTION
### Motivation
- Users could hit a black screen when navigating to protected routes or quick-action dialogs immediately after app boot because a lazy chunk threw while loading and there was no safe recovery path.
- The goal is to make route/dialog dynamic imports more resilient to transient chunk-load failures and show a friendly in-app fallback instead of collapsing the protected shell.

### Description
- Add a `lazyWithRetry` helper to retry a failing dynamic `import()` once after a short delay before letting it error. The helper is used for route and dialog lazy imports (`Home`, `Workout`, `Analytics`, `Coach`, `Settings`, `NotFound`, and quick-action dialogs). (file: `src/components/layout/MainAppLayout.tsx`)
- Add a `RouteErrorBoundary` around the `Suspense` tree so a thrown lazy-load error renders a small in-app message instead of a full black screen. (file: `src/components/layout/MainAppLayout.tsx`)
- Preserve the existing `RouteFallback` loading skeleton as the `Suspense` fallback and wire the retry/error-boundary flow around it. (file: `src/components/layout/MainAppLayout.tsx`)

### Testing
- Ran `npm run build` and the production build completed successfully. (success)
- Ran `npm run lint` and it completed with the repo's existing warning baseline (8 warnings, 0 errors). (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5e6f3f0c832cb56a76375a1c53cd)