### PR TITLE
Fix RouteErrorBoundary recovery after lazy-load failures

### DIFF
--- a/src/components/layout/MainAppLayout.tsx
+++ b/src/components/layout/MainAppLayout.tsx
@@ -28,7 +28,7 @@ const lazyWithRetry = <TModule extends { default: React.ComponentType<unknown> }
   });
 
 class RouteErrorBoundary extends Component<
-  { children: ReactNode },
+  { children: ReactNode; resetKey: string },
   { hasError: boolean }
 > {
   state = { hasError: false };
@@ -37,12 +37,25 @@ class RouteErrorBoundary extends Component<
     return { hasError: true };
   }
 
+  componentDidUpdate(prevProps: Readonly<{ children: ReactNode; resetKey: string }>) {
+    if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false });
+    }
+  }
+
+  private handleRetry = () => {
+    this.setState({ hasError: false });
+  };
+
   render() {
     if (this.state.hasError) {
       return (
         <div className="app-page">
-          <div className="stone-surface rounded-[26px] p-6 text-sm text-muted-foreground">
-            We couldn&apos;t load this screen yet. Please try again.
+          <div className="stone-surface rounded-[26px] p-6 text-sm text-muted-foreground space-y-3">
+            <p>We couldn&apos;t load this screen yet. Please try again.</p>
+            <Button onClick={this.handleRetry} size="sm" variant="outline">
+              Retry loading
+            </Button>
           </div>
         </div>
       );
@@ -106,7 +119,7 @@ const MainAppLayout = () => {
         <NavBar />
       </div>
       <SidebarInset className="app-shell">
-        <RouteErrorBoundary>
+        <RouteErrorBoundary resetKey={location.key}>
           <Suspense fallback={<RouteFallback />}>
             <Routes>
               <Route path="/" element={<Home />} />


### PR DESCRIPTION
### Motivation
- A lazy-import failure caused `RouteErrorBoundary` to flip `hasError` permanently, turning transient CDN/connectivity import errors into persistent outages that required a full reload. 

### Description
- Update `RouteErrorBoundary` in `src/components/layout/MainAppLayout.tsx` to accept a `resetKey` prop and clear `hasError` when `resetKey` changes. 
- Add a local “Retry loading” button that clears the error state so users can re-attempt rendering without reloading the page. 
- Pass `location.key` into the boundary (`<RouteErrorBoundary resetKey={location.key}>`) so navigation automatically resets the boundary after route changes. 

### Testing
- Ran `npm run build` and the build completed successfully (with existing chunk-size warnings). 
- Ran `npm run lint` and lint finished successfully, reporting the repository’s baseline 8 warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df66b76580832cb70c677e026a7895)