### PR TITLE
Add Google one-click auth option to login form

### DIFF
--- a/src/domains/account/ui/AuthForm.tsx
+++ b/src/domains/account/ui/AuthForm.tsx
@@ -24,7 +24,8 @@ export const AuthForm = () => {
             supabaseClient={supabase}
             view="sign_in"
             showLinks={true}
-            providers={[]}
+            providers={["google"]}
+            redirectTo={window.location.origin}
             dark={true}
             localization={{
               variables: {


### PR DESCRIPTION
### Motivation
- Enable one-click sign up / sign in with Google using the existing Supabase Auth UI so users can quickly authenticate with their Google account.

### Description
- Turn on the Google social provider in the Supabase `Auth` component by setting `providers={["google"]}` and add `redirectTo={window.location.origin}` in `src/domains/account/ui/AuthForm.tsx` so OAuth returns to the app.

### Testing
- Ran `npm run build` which completed successfully, and ran `npm run lint` which completed successfully with the repository's existing 8 warnings baseline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9b77e54c832c958cc0fc6fd771a5)