### PR TITLE
Auto-stop warm-up timer on first completed set

### DIFF
--- a/src/state/workout/workoutSlice.ts
+++ b/src/state/workout/workoutSlice.ts
@@ -236,6 +236,10 @@ const workoutSlice = createSlice({
         const set = workoutExercise.sets.find((s) => s.id === action.payload.setId);
         if (set) {
             set.completed = action.payload.completed;
+            if (action.payload.completed && state.warmupStartTime) {
+                state.currentWorkout.warmup_seconds = Math.round((Date.now() - state.warmupStartTime) / 1000);
+                state.warmupStartTime = null;
+            }
         }
     },
     updateWorkoutExerciseEquipment(state, action: PayloadAction<{ workoutExerciseId: string; equipmentType: string }>) {


### PR DESCRIPTION
### Motivation
- Prevent workouts from remaining in a running warm-up state (and failing to save) when users forget to stop warm-up before completing their first set, improving save-flow resilience and UX.

### Description
- Updated the workout reducer in `src/state/workout/workoutSlice.ts` to automatically capture `warmup_seconds` and clear `warmupStartTime` when any set is marked complete while a warm-up is active. 
- This change records the elapsed warm-up time at the moment of the first completion so subsequent save/discard flows treat the warm-up as stopped.

### Testing
- Ran `npm run build` which completed successfully. 
- Ran `npm run lint` which completed successfully with the existing baseline warnings (8 warnings, 0 errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d15bb108832c86c42f090e508ef7)