### PR TITLE
Refactor workout selection UI styles and restyle selectors/inputs

### DIFF
--- a/src/domains/fitness/ui/AddSingleExerciseDialog.tsx
+++ b/src/domains/fitness/ui/AddSingleExerciseDialog.tsx
@@ -11,11 +11,17 @@ import { Button } from "@/components/core/button";
 import { Loader2, Check, X as XIcon } from 'lucide-react';
 import { Input } from "@/components/core/input";
 import { Label } from "@/components/core/label";
+import { cn } from '@/lib/utils/cn';
 import EquipmentSelector from './EquipmentSelector';
 import VariationSelector from './VariationSelector';
 import SwipeableIncrementer from '@/components/core/Controls/SwipeableIncrementer';
 import { useSingleExerciseLog } from '../hooks/useSingleExerciseLog';
 import type { LatestSingleExerciseLogData } from '../data/fitnessRepository';
+import {
+  workoutMenuInputClassName,
+  workoutMenuSelectTriggerClassName,
+  workoutPanelClassName,
+} from './workoutSelectionStyles';
 
 // --- Constants ---
 const DEFAULT_VARIATION = 'Standard';
@@ -84,7 +90,7 @@ const AddSingleExerciseDialog: React.FC<AddSingleExerciseDialogProps> = ({ open,
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[480px]">
+      <DialogContent className={cn(workoutPanelClassName, "rounded-[24px] border-white/10 sm:max-w-[480px]")}>
         <DialogHeader>
           <DialogTitle>Add Single Exercise</DialogTitle>
           <DialogDescription>
@@ -104,7 +110,7 @@ const AddSingleExerciseDialog: React.FC<AddSingleExerciseDialogProps> = ({ open,
                   id="exercise-select"
                   value={form.exerciseId}
                   onChange={(e) => updateField('exerciseId', e.target.value)}
-                  className="block w-full min-w-[150px] p-2 h-9 border border-input bg-background rounded-md shadow-sm focus:outline-none focus:ring-ring focus:border-ring text-sm"
+                  className={cn(workoutMenuSelectTriggerClassName, "h-10 w-full min-w-[150px] appearance-none px-3 text-sm")}
                   disabled={isPending}
                 >
                   <option value="" disabled>Select Exercise...</option>
@@ -127,13 +133,13 @@ const AddSingleExerciseDialog: React.FC<AddSingleExerciseDialogProps> = ({ open,
                 setPopoverOpen={setEquipmentPopoverOpen}
               />
               {isAddingVariation ? (
-                <div className="flex items-center gap-1 flex-shrink-0 h-8">
+                <div className="flex h-10 flex-shrink-0 items-center gap-1">
                   <Input
                     type="text"
                     placeholder="New Variation Name"
                     value={newVariationName}
                     onChange={(e) => setNewVariationName(e.target.value)}
-                    className="h-full w-[120px] sm:w-[150px] text-xs"
+                    className={cn(workoutMenuInputClassName, "h-full w-[120px] text-xs sm:w-[150px]")}
                     disabled={isPending}
                     autoFocus
                     onKeyDown={(e) => { if (e.key === 'Enter') handleSaveNewVariation(); if (e.key === 'Escape') handleCancelAddNewVariation(); }}
@@ -141,7 +147,7 @@ const AddSingleExerciseDialog: React.FC<AddSingleExerciseDialogProps> = ({ open,
                   <Button
                     size="icon"
                     variant="ghost"
-                    className="h-full w-8 text-green-600 hover:bg-green-100 dark:hover:bg-green-900/50 flex-shrink-0"
+                    className="verdigris-emblem h-full w-10 flex-shrink-0 rounded-[14px] hover:bg-white/[0.04]"
                     onClick={handleSaveNewVariation}
                     disabled={!newVariationName.trim() || isPending}
                     aria-label="Save new variation"
@@ -151,7 +157,7 @@ const AddSingleExerciseDialog: React.FC<AddSingleExerciseDialogProps> = ({ open,
                   <Button
                     size="icon"
                     variant="ghost"
-                    className="h-full w-8 text-red-600 hover:bg-red-100 dark:hover:bg-red-900/50 flex-shrink-0"
+                    className="stone-chip h-full w-10 flex-shrink-0 rounded-[14px] text-muted-foreground hover:bg-white/[0.05] hover:text-foreground"
                     onClick={handleCancelAddNewVariation}
                     disabled={isPending}
                     aria-label="Cancel adding variation"
@@ -189,7 +195,7 @@ const AddSingleExerciseDialog: React.FC<AddSingleExerciseDialogProps> = ({ open,
                   step="0.5"
                   min="0"
                   inputMode="decimal"
-                  className="block w-full p-2 border border-input bg-background rounded-md shadow-sm focus:outline-none focus:ring-ring focus:border-ring sm:text-sm text-center"
+                  className={cn(workoutMenuInputClassName, "block w-full px-3 text-center sm:text-sm")}
                   placeholder="0"
                   disabled={isPending}
                 />
@@ -225,7 +231,7 @@ const AddSingleExerciseDialog: React.FC<AddSingleExerciseDialogProps> = ({ open,
                     min="1"
                     inputMode="numeric"
                     pattern="[0-9]*"
-                    className="block w-full p-2 border border-input bg-background rounded-md shadow-sm focus:outline-none focus:ring-ring focus:border-ring sm:text-sm text-center"
+                    className={cn(workoutMenuInputClassName, "block w-full px-3 text-center sm:text-sm")}
                     placeholder="Enter time"
                     disabled={isPending || !form.exerciseId}
                   />
@@ -259,7 +265,7 @@ const AddSingleExerciseDialog: React.FC<AddSingleExerciseDialogProps> = ({ open,
                     min="1"
                     inputMode="numeric"
                     pattern="[0-9]*"
-                    className="block w-full p-2 border border-input bg-background rounded-md shadow-sm focus:outline-none focus:ring-ring focus:border-ring sm:text-sm text-center"
+                    className={cn(workoutMenuInputClassName, "block w-full px-3 text-center sm:text-sm")}
                     placeholder="Enter reps"
                     disabled={isPending || !form.exerciseId}
                   />

--- a/src/domains/fitness/ui/EquipmentSelector.tsx
+++ b/src/domains/fitness/ui/EquipmentSelector.tsx
@@ -2,7 +2,13 @@ import React, { useState } from 'react';
 import { Button } from "@/components/core/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/core/popover";
 import { Input } from "@/components/core/input";
-import { Check, X, Plus } from 'lucide-react';
+import { Check, ChevronDown, X, Plus } from 'lucide-react';
+import { cn } from '@/lib/utils/cn';
+import {
+  workoutMenuInputClassName,
+  workoutMenuOptionClassName,
+  workoutPopoverClassName,
+} from './workoutSelectionStyles';
 
 interface EquipmentSelectorProps {
   selectedEquipment: string | null;
@@ -48,22 +54,23 @@ const EquipmentSelector: React.FC<EquipmentSelectorProps> = ({
     }}>
       <PopoverTrigger asChild>
         <Button
-          variant="outline"
+          variant="ghost"
           size="sm"
-          className="rounded-full h-7 px-2.5 text-xs w-auto border-border"
+          className="stone-chip h-10 min-w-[124px] justify-between rounded-[14px] px-3 text-xs text-foreground/88 hover:bg-white/[0.05] hover:text-foreground"
           disabled={disabled}
         >
-          {selectedEquipment ?? "Equipment"}
+          <span className="truncate">{selectedEquipment ?? "Equipment"}</span>
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-1">
+      <PopoverContent className={workoutPopoverClassName}>
         <div className="flex flex-col gap-1">
           {equipmentTypes.map((type) => (
             <Button
               key={type}
               variant="ghost"
               size="sm"
-              className="w-full justify-start h-8 px-2 text-xs"
+              className={workoutMenuOptionClassName}
               onClick={() => {
                 onSelectEquipment(type);
                 setShowNewEquipmentInput(false);
@@ -74,8 +81,7 @@ const EquipmentSelector: React.FC<EquipmentSelectorProps> = ({
               {type}
             </Button>
           ))}
-          {/* Add New Equipment Button / Input */} 
-          <div className="mt-1 pt-1 border-t border-border">
+          <div className="mt-2 border-t border-white/8 pt-2">
             {showNewEquipmentInput ? (
               <div className="flex items-center gap-1">
                 <Input
@@ -83,17 +89,17 @@ const EquipmentSelector: React.FC<EquipmentSelectorProps> = ({
                   placeholder="New Equipment"
                   value={newEquipmentName}
                   onChange={(e) => setNewEquipmentName(e.target.value)}
-                  className="h-8 px-2 text-xs flex-grow"
+                  className={cn(workoutMenuInputClassName, "h-10 flex-grow px-3 text-xs")}
                   autoFocus
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') handleAddNewEquipment();
                     if (e.key === 'Escape') handleCancelAddNew();
                   }}
                 />
-                <Button variant="ghost" size="icon" className="h-8 w-8 p-0" onClick={handleAddNewEquipment} disabled={!newEquipmentName.trim()}>
+                <Button variant="ghost" size="icon" className="verdigris-emblem h-10 w-10 rounded-[14px] p-0 hover:bg-white/[0.04]" onClick={handleAddNewEquipment} disabled={!newEquipmentName.trim()}>
                   <Check size={16} />
                 </Button>
-                <Button variant="ghost" size="icon" className="h-8 w-8 p-0" onClick={handleCancelAddNew}>
+                <Button variant="ghost" size="icon" className="stone-chip h-10 w-10 rounded-[14px] p-0 text-muted-foreground hover:bg-white/[0.05] hover:text-foreground" onClick={handleCancelAddNew}>
                   <X size={16} />
                 </Button>
               </div>
@@ -101,7 +107,7 @@ const EquipmentSelector: React.FC<EquipmentSelectorProps> = ({
               <Button
                 variant="ghost"
                 size="sm"
-                className="w-full justify-start h-8 px-2 text-xs text-blue-600 dark:text-blue-400"
+                className={`${workoutMenuOptionClassName} verdigris-text hover:text-foreground`}
                 onClick={() => {
                   setShowNewEquipmentInput(true);
                   setNewEquipmentName("");

--- a/src/domains/fitness/ui/VariationSelector.tsx
+++ b/src/domains/fitness/ui/VariationSelector.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import { Button } from "@/components/core/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/core/popover";
-import { Loader2, Plus } from 'lucide-react';
+import { ChevronDown, Loader2, Plus } from 'lucide-react';
 import type { ExerciseVariationRow } from '../data/fitnessRepository';
+import {
+  workoutMenuOptionClassName,
+  workoutPopoverClassName,
+} from './workoutSelectionStyles';
 
 interface VariationSelectorProps {
   selectedVariation: string | null;
@@ -31,38 +35,37 @@ const VariationSelector: React.FC<VariationSelectorProps> = ({
     <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
       <PopoverTrigger asChild>
         <Button
-          variant="outline"
+          variant="ghost"
           size="sm"
-          className="rounded-full h-7 px-2.5 text-xs w-auto border-border min-w-[90px] justify-center"
+          className="stone-chip h-10 min-w-[124px] justify-between rounded-[14px] px-3 text-xs text-foreground/88 hover:bg-white/[0.05] hover:text-foreground"
           disabled={disabled || isLoading}
         >
-          {isLoading ? <Loader2 className="h-3 w-3 animate-spin" /> : (selectedVariation ?? defaultVariationText)}
+          <span className="truncate">{isLoading ? "Loading..." : (selectedVariation ?? defaultVariationText)}</span>
+          {isLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-1">
+      <PopoverContent className={workoutPopoverClassName}>
         <div className="flex flex-col gap-1">
-          {/* Default/Standard Option - only if defaultVariationText is meaningful */}
           {defaultVariationText && (
             <Button
               variant="ghost"
               size="sm"
-              className="w-full justify-start h-8 px-2 text-xs italic"
+              className={workoutMenuOptionClassName}
               onClick={() => {
-                onSelectVariation(null); // Represents selecting the default
+                onSelectVariation(null);
                 setPopoverOpen(false);
               }}
-              disabled={selectedVariation === null} // Disabled if already on default
+              disabled={selectedVariation === null}
             >
               {defaultVariationText}
             </Button>
           )}
-          {/* Database fetched variations */}
           {variations.map((variation) => (
             <Button
-              key={variation.id} // Use the unique ID from the database object
+              key={variation.id}
               variant="ghost"
               size="sm"
-              className="w-full justify-start h-8 px-2 text-xs"
+              className={workoutMenuOptionClassName}
               onClick={() => {
                 onSelectVariation(variation.variation_name);
                 setPopoverOpen(false);
@@ -72,19 +75,20 @@ const VariationSelector: React.FC<VariationSelectorProps> = ({
               {variation.variation_name}
             </Button>
           ))}
-          {/* Add New Variation Button */}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="w-full justify-start h-8 px-2 text-xs text-blue-600 dark:text-blue-400 mt-1 pt-1 border-t border-border"
-            onClick={() => {
-              onTriggerAddNewVariation();
-              setPopoverOpen(false);
-            }}
-            disabled={isLoading}
-          >
-            <Plus size={14} className="mr-1" /> Add New
-          </Button>
+          <div className="mt-2 border-t border-white/8 pt-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className={`${workoutMenuOptionClassName} verdigris-text hover:text-foreground`}
+              onClick={() => {
+                onTriggerAddNewVariation();
+                setPopoverOpen(false);
+              }}
+              disabled={isLoading}
+            >
+              <Plus size={14} className="mr-1" /> Add New
+            </Button>
+          </div>
         </div>
       </PopoverContent>
     </Popover>

--- a/src/domains/fitness/ui/WorkoutScreen.tsx
+++ b/src/domains/fitness/ui/WorkoutScreen.tsx
@@ -485,9 +485,9 @@ const WorkoutScreen = () => {
             </Button>
             <DialogClose asChild>
               <Button
-                variant="destructive"
+                variant="ghost"
                 onClick={handleConfirmDiscard}
-                className="rounded-[16px]"
+                className="h-10 rounded-[16px] border border-rose-500/30 bg-rose-500/12 px-4 text-rose-200 hover:bg-rose-500/18 hover:text-rose-100"
               >
                 Discard
               </Button>


### PR DESCRIPTION
### Motivation

- Unify and modernize the workout selection UI by applying shared style tokens and improving the appearance and spacing of selectors, inputs, and popovers.

### Description

- Introduced and used shared style names from `workoutSelectionStyles` and the `cn` utility across `AddSingleExerciseDialog`, `EquipmentSelector`, and `VariationSelector` to standardize menu triggers, inputs, options, and popover content.
- Restyled selector buttons to use `variant="ghost"`, added `ChevronDown` indicators, increased control heights to `h-10`, and replaced several raw class strings with composed class constants for consistent visuals.
- Reworked add-new input/button layouts inside popovers with updated sizes and rounded corners, and replaced some icon/button classes with `verdigris-emblem` / `stone-chip` variants for consistent theming.
- Adjusted the discard confirmation button in `WorkoutScreen` to a ghost style with a bordered/red accent and updated classes for consistent spacing and sizing.

### Testing

- Ran TypeScript type check (`yarn tsc`) to ensure typings are valid and no type regressions were introduced, and it completed successfully.
- Executed the project's unit test suite (`yarn test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d1c7aa78832ca1d6bc5a0a76b3eb)