### PR TITLE
Fix workout selector background and discard dialog clipping

### DIFF
--- a/src/domains/fitness/ui/WorkoutExerciseView.tsx
+++ b/src/domains/fitness/ui/WorkoutExerciseView.tsx
@@ -468,7 +468,7 @@ export const WorkoutExerciseView = ({
     Math.abs(cardSwipeOffset) / SWIPE_REVEAL_WIDTH
   );
   const chipButtonClassName =
-    "stone-chip h-8 rounded-[10px] border-0 px-2.5 text-[13px] font-medium text-foreground/76 shadow-none hover:bg-white/[0.05] hover:text-foreground";
+    "h-8 rounded-[10px] border border-white/10 bg-white/[0.03] px-2.5 text-[13px] font-medium text-foreground/76 shadow-none hover:bg-white/[0.05] hover:text-foreground";
 
   return (
     <Fragment>

--- a/src/domains/fitness/ui/WorkoutExerciseView.tsx
+++ b/src/domains/fitness/ui/WorkoutExerciseView.tsx
@@ -468,7 +468,7 @@ export const WorkoutExerciseView = ({
     Math.abs(cardSwipeOffset) / SWIPE_REVEAL_WIDTH
   );
   const chipButtonClassName =
-    "h-8 rounded-[10px] border-0 bg-transparent px-2.5 text-[13px] font-medium text-foreground/76 shadow-none hover:bg-transparent hover:text-foreground";
+    "stone-chip h-8 rounded-[10px] border-0 px-2.5 text-[13px] font-medium text-foreground/76 shadow-none hover:bg-white/[0.05] hover:text-foreground";
 
   return (
     <Fragment>

--- a/src/domains/fitness/ui/WorkoutScreen.tsx
+++ b/src/domains/fitness/ui/WorkoutScreen.tsx
@@ -467,7 +467,7 @@ const WorkoutScreen = () => {
       </div>
 
       <Dialog open={isDiscardConfirmOpen} onOpenChange={setIsDiscardConfirmOpen}>
-        <DialogContent className="stone-panel rounded-[24px] border-white/10">
+        <DialogContent className="stone-panel w-[calc(100vw-2rem)] max-w-lg rounded-[24px] border-white/10">
           <DialogHeader>
             <DialogTitle>Discard Workout?</DialogTitle>
             <DialogDescription>


### PR DESCRIPTION
### Motivation
- Ensure the equipment and variation selector buttons use the same gray surface as other UI chips and prevent the discard confirmation dialog from being clipped on narrow viewports.

### Description
- Replace the transparent chip styling with the shared `stone-chip` surface in `src/domains/fitness/ui/WorkoutExerciseView.tsx` so equipment/variation collectors match the rest of the UI.
- Constrain the discard confirmation dialog in `src/domains/fitness/ui/WorkoutScreen.tsx` by adding `w-[calc(100vw-2rem)] max-w-lg` to avoid right-edge overflow on small screens.

### Testing
- Ran `npm run build`, which completed successfully.
- Ran `npm run lint`, which completed and shows the existing baseline warnings (8 warnings, 0 errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2475c8014832cbe45de441d34d237)