### PR TITLE
Tone down dropdown action styling to neutral

### DIFF
--- a/src/domains/fitness/ui/AddSingleExerciseDialog.tsx
+++ b/src/domains/fitness/ui/AddSingleExerciseDialog.tsx
@@ -147,7 +147,7 @@ const AddSingleExerciseDialog: React.FC<AddSingleExerciseDialogProps> = ({ open,
                   <Button
                     size="icon"
                     variant="ghost"
-                    className="verdigris-emblem h-full w-10 flex-shrink-0 rounded-[14px] hover:bg-white/[0.04]"
+                    className="stone-chip h-full w-10 flex-shrink-0 rounded-[14px] text-foreground/88 hover:bg-white/[0.05] hover:text-foreground"
                     onClick={handleSaveNewVariation}
                     disabled={!newVariationName.trim() || isPending}
                     aria-label="Save new variation"

--- a/src/domains/fitness/ui/EquipmentSelector.tsx
+++ b/src/domains/fitness/ui/EquipmentSelector.tsx
@@ -96,7 +96,7 @@ const EquipmentSelector: React.FC<EquipmentSelectorProps> = ({
                     if (e.key === 'Escape') handleCancelAddNew();
                   }}
                 />
-                <Button variant="ghost" size="icon" className="verdigris-emblem h-10 w-10 rounded-[14px] p-0 hover:bg-white/[0.04]" onClick={handleAddNewEquipment} disabled={!newEquipmentName.trim()}>
+                <Button variant="ghost" size="icon" className="stone-chip h-10 w-10 rounded-[14px] p-0 text-foreground/88 hover:bg-white/[0.05] hover:text-foreground" onClick={handleAddNewEquipment} disabled={!newEquipmentName.trim()}>
                   <Check size={16} />
                 </Button>
                 <Button variant="ghost" size="icon" className="stone-chip h-10 w-10 rounded-[14px] p-0 text-muted-foreground hover:bg-white/[0.05] hover:text-foreground" onClick={handleCancelAddNew}>
@@ -107,7 +107,7 @@ const EquipmentSelector: React.FC<EquipmentSelectorProps> = ({
               <Button
                 variant="ghost"
                 size="sm"
-                className={`${workoutMenuOptionClassName} verdigris-text hover:text-foreground`}
+                className={`${workoutMenuOptionClassName} text-muted-foreground hover:text-foreground`}
                 onClick={() => {
                   setShowNewEquipmentInput(true);
                   setNewEquipmentName("");

--- a/src/domains/fitness/ui/VariationSelector.tsx
+++ b/src/domains/fitness/ui/VariationSelector.tsx
@@ -79,7 +79,7 @@ const VariationSelector: React.FC<VariationSelectorProps> = ({
             <Button
               variant="ghost"
               size="sm"
-              className={`${workoutMenuOptionClassName} verdigris-text hover:text-foreground`}
+              className={`${workoutMenuOptionClassName} text-muted-foreground hover:text-foreground`}
               onClick={() => {
                 onTriggerAddNewVariation();
                 setPopoverOpen(false);

--- a/src/domains/fitness/ui/WorkoutExerciseView.tsx
+++ b/src/domains/fitness/ui/WorkoutExerciseView.tsx
@@ -585,7 +585,7 @@ export const WorkoutExerciseView = ({
                           <Button
                             variant="ghost"
                             size="icon"
-                            className="verdigris-emblem h-10 w-10 rounded-[14px] p-0 hover:bg-white/[0.04]"
+                            className="stone-chip h-10 w-10 rounded-[14px] p-0 text-foreground/88 hover:bg-white/[0.05] hover:text-foreground"
                             onClick={() => {
                               if (newEquipmentName.trim()) {
                                 onEquipmentChange(newEquipmentName.trim());
@@ -616,7 +616,7 @@ export const WorkoutExerciseView = ({
                         <Button
                           variant="ghost"
                           size="sm"
-                          className={cn(workoutMenuOptionClassName, "verdigris-text hover:text-foreground")}
+                          className={cn(workoutMenuOptionClassName, "text-muted-foreground hover:text-foreground")}
                           onClick={() => {
                             setShowNewEquipmentInput(true);
                             setNewEquipmentName("");
@@ -664,7 +664,7 @@ export const WorkoutExerciseView = ({
                         <Button
                           variant="ghost"
                           size="sm"
-                          className={cn(workoutMenuOptionClassName, "verdigris-text hover:text-foreground")}
+                          className={cn(workoutMenuOptionClassName, "text-muted-foreground hover:text-foreground")}
                           onClick={() => {
                             onVariationChange('add_new');
                             setVariationOpen(false);
@@ -690,7 +690,7 @@ export const WorkoutExerciseView = ({
                   <Button
                     size="icon"
                     variant="ghost"
-                    className="verdigris-emblem h-10 w-10 flex-shrink-0 rounded-[14px] hover:bg-white/[0.04]"
+                    className="stone-chip h-10 w-10 flex-shrink-0 rounded-[14px] text-foreground/88 hover:bg-white/[0.05] hover:text-foreground"
                     onClick={onSaveNewVariation}
                     disabled={!newVariationName.trim() || newVariationName.trim().toLowerCase() === DEFAULT_VARIATION.toLowerCase() || isSavingVariation}
                     aria-label="Save new variation"


### PR DESCRIPTION
### Motivation
- The equipment and variation dropdowns introduced a green/verdigris accent for action rows and icon buttons which conflicts with the app's neutral design language and appears in multiple dropdown patterns.
- Restore a more neutral, consistent visual treatment for dropdown action rows while keeping the selector components and interactions unchanged.

### Description
- Replaced green/verdigris action styles with neutral `stone-chip` / muted foreground classes for add/save/cancel controls inside dropdowns and popovers.
- Normalized the “Add New” action row text from `verdigris-text` to `text-muted-foreground` in dropdown menus.
- Applied the same neutral styling across related components to ensure consistency in workout flows, touching `EquipmentSelector`, `VariationSelector`, `WorkoutExerciseView`, and `AddSingleExerciseDialog`.
- Files modified: `src/domains/fitness/ui/EquipmentSelector.tsx`, `src/domains/fitness/ui/VariationSelector.tsx`, `src/domains/fitness/ui/WorkoutExerciseView.tsx`, and `src/domains/fitness/ui/AddSingleExerciseDialog.tsx`.

### Testing
- Ran `npm run build` successfully (production build completed). 
- Ran `npm run lint` successfully; repo remains at the existing baseline of 8 warnings and 0 errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f48e7aeb18832c9e1eb03224d557ff)