### PR TITLE
Make set load indicator clickable to apply recommended weight

### DIFF
--- a/src/domains/fitness/hooks/useSet.ts
+++ b/src/domains/fitness/hooks/useSet.ts
@@ -348,6 +348,25 @@ export const useSet = ({
         }
     }, [dispatch, workoutExerciseId, set, isStatic, isCompleted, localWeight, localReps, localTime, localDuration, localDistance]);
 
+
+    const applyRecommendedWeight = useCallback(() => {
+        if (!isStrengthSet(set) || isCompleted || !recommendedPerformance) return;
+        if (recommendedPerformance.action !== 'increase_load' && recommendedPerformance.action !== 'decrease_load') return;
+
+        const recommendedWeight = recommendedPerformance.weight;
+        setLocalWeight(String(recommendedWeight));
+        setWeightTouched(true);
+
+        dispatch(updateSetAction({
+            workoutExerciseId,
+            setId: set.id,
+            weight: recommendedWeight,
+            reps: set.reps,
+            time: set.time ?? null,
+            variation: set.variation ?? undefined,
+            equipmentType: set.equipmentType ?? undefined,
+        }));
+    }, [dispatch, workoutExerciseId, set, isCompleted, recommendedPerformance]);
     // Derived values for indicators
     const showWeightIndicator = !!(
         recommendedPerformance &&
@@ -389,6 +408,7 @@ export const useSet = ({
         handleStopCardioTimer,
         showWeightIndicator,
         showRepsIndicator,
-        showTimeIndicator
+        showTimeIndicator,
+        applyRecommendedWeight
     };
 };

--- a/src/domains/fitness/ui/PerformanceIndicator.tsx
+++ b/src/domains/fitness/ui/PerformanceIndicator.tsx
@@ -6,12 +6,14 @@ interface PerformanceIndicatorProps {
   direction: 'up' | 'down' | null;
   visible: boolean;
   description?: string;
+  onClick?: () => void;
 }
 
 const PerformanceIndicator: React.FC<PerformanceIndicatorProps> = ({
   direction,
   visible,
-  description
+  description,
+  onClick
 }) => {
   if (!visible || !direction) {
     return null;
@@ -21,15 +23,20 @@ const PerformanceIndicator: React.FC<PerformanceIndicatorProps> = ({
   const colorClass = direction === 'up' ? "verdigris-text" : "warm-metal-text";
 
   return (
-    <IconComponent
-      size={16}
-      className={cn(
-        "absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none",
-        colorClass
-      )}
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!onClick}
+      className="absolute right-2 top-1/2 -translate-y-1/2"
+      aria-label={description ?? "Apply performance recommendation"}
       title={description}
-      aria-hidden="true"
-    />
+    >
+      <IconComponent
+        size={16}
+        className={cn("transition-opacity", colorClass)}
+        aria-hidden="true"
+      />
+    </button>
   );
 };
 

--- a/src/domains/fitness/ui/SetComponent.tsx
+++ b/src/domains/fitness/ui/SetComponent.tsx
@@ -67,7 +67,8 @@ const SetComponent: React.FC<SetComponentProps> = ({
     handleStopCardioTimer,
     showWeightIndicator,
     showRepsIndicator,
-    showTimeIndicator
+    showTimeIndicator,
+    applyRecommendedWeight
   } = useSet({
     workoutExerciseId,
     set,
@@ -293,7 +294,8 @@ const SetComponent: React.FC<SetComponentProps> = ({
             <PerformanceIndicator
               direction={weightIndicatorDirection}
               visible={showWeightIndicator && !isCompleted}
-              description={weightIndicatorDirection === 'up' ? 'Increase load.' : 'Reduce load.'}
+              description={weightIndicatorDirection === 'up' ? 'Apply recommended load increase.' : 'Apply recommended load reduction.'}
+              onClick={applyRecommendedWeight}
             />
           </>,
           isCompleted ? onSwipeCopyWeight : undefined


### PR DESCRIPTION
### Motivation
- Users should be able to accept progressive-overload recommendations directly from the set row rather than manually typing the suggested load. 
- The change aims to reduce friction by making the performance indicator actionable for weight changes while preserving existing update paths and UX guards.

### Description
- Turned the `PerformanceIndicator` into an interactive control by adding an optional `onClick` prop and rendering a button containing the direction icon instead of a passive icon (`src/domains/fitness/ui/PerformanceIndicator.tsx`).
- Wired the weight indicator in `SetComponent` to call a new handler and updated the tooltip text to indicate the click will apply the recommendation (`src/domains/fitness/ui/SetComponent.tsx`).
- Added `applyRecommendedWeight` in `useSet` which applies the recommended load to local inputs, marks the weight field as touched, and persists the change via the existing `updateSetAction` (only for `increase_load` / `decrease_load` actions and while the set is editable) (`src/domains/fitness/hooks/useSet.ts`).

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran `npm run lint` and it passed with the existing baseline warnings (8 warnings, 0 errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4950f3dd8832ca54cea2ef7256402)