### PR TITLE
Polish workout selectors and preserve reps placeholder state

### DIFF
--- a/src/domains/fitness/hooks/useSet.ts
+++ b/src/domains/fitness/hooks/useSet.ts
@@ -317,9 +317,14 @@ export const useSet = ({
                     dispatch(updateSetAction(updatePayload));
                 }
             } else {
+                const parsedRepsVal = parseInt(localReps);
+                const nextRepsValue =
+                    field === 'reps'
+                        ? (Number.isNaN(parsedRepsVal) ? null : parsedRepsVal)
+                        : set.reps;
                 const updatePayload: StrengthSetUpdatePayload = {
                     ...baseUpdatePayload,
-                    reps: repsVal,
+                    reps: nextRepsValue,
                     time: null,
                 };
                 if (field === 'weight' && weightVal >= 0 && weightVal !== set.weight) shouldUpdate = true;

--- a/src/domains/fitness/ui/WorkoutExerciseView.tsx
+++ b/src/domains/fitness/ui/WorkoutExerciseView.tsx
@@ -468,7 +468,7 @@ export const WorkoutExerciseView = ({
     Math.abs(cardSwipeOffset) / SWIPE_REVEAL_WIDTH
   );
   const chipButtonClassName =
-    "h-8 rounded-[10px] border border-white/10 bg-white/[0.03] px-2.5 text-[13px] font-medium text-foreground/76 shadow-none hover:bg-white/[0.05] hover:text-foreground";
+    "h-8 rounded-[10px] border-0 bg-transparent px-1.5 text-[13px] font-medium text-foreground/76 shadow-none hover:bg-transparent hover:text-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0";
 
   return (
     <Fragment>

--- a/src/domains/fitness/ui/workoutSelectionStyles.ts
+++ b/src/domains/fitness/ui/workoutSelectionStyles.ts
@@ -9,7 +9,7 @@ export const workoutMenuInputClassName =
   "stone-inset h-11 rounded-[16px] text-sm text-foreground shadow-none placeholder:text-muted-foreground/80 focus-visible:ring-0 focus-visible:ring-offset-0";
 
 export const workoutMenuOptionClassName =
-  "h-10 w-full justify-start rounded-[12px] border border-transparent px-3 text-[13px] font-medium text-foreground/88 hover:bg-white/[0.03] hover:text-foreground disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-foreground/88";
+  "h-10 w-full justify-start rounded-[12px] border border-transparent bg-transparent px-3 text-[13px] font-medium text-foreground/88 hover:bg-white/[0.03] hover:text-foreground focus-visible:bg-white/[0.03] focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=open]:bg-transparent data-[state=open]:text-foreground disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-foreground/88";
 
 export const workoutMenuSectionClassName =
   "stone-surface rounded-[20px] p-3";


### PR DESCRIPTION
### Motivation
- Align equipment and variation selector visuals with the current design by removing outlines and background fills from the trigger chips so they appear as text-only controls with a chevron affordance. 
- Stop selector menu rows from adopting an accent/open-state fill (the green background) so popover lists match the stone-style menu treatment. 
- Prevent weight edits from implicitly marking reps as filled so the reps placeholder stays the muted/gray indicator until the user explicitly enters reps.

### Description
- Changed the selector trigger chip styling in `src/domains/fitness/ui/WorkoutExerciseView.tsx` by replacing the bordered/filled class with a text-first, `bg-transparent` `border-0` chip and removed focus ring styles. 
- Updated menu option classes in `src/domains/fitness/ui/workoutSelectionStyles.ts` to explicitly keep rows `bg-transparent` on open/focus and add `focus-visible` rules to avoid accent fills. 
- Modified the set blur/update logic in `src/domains/fitness/hooks/useSet.ts` to parse `localReps` and only include a reps value when the reps field was the one changed; otherwise the payload preserves the existing `set.reps` (so the placeholder/gray visual remains until reps are entered).

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran `npm run lint` and lint finished with the existing baseline warnings (8 warnings, 0 errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8695ab378832c9ae1d230f3b152cf)