### PR TITLE
Seed focus-aware mesocycle templates and remove protocol selector

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -233,7 +233,7 @@ Current Coach architecture:
 - Purpose: mesocycles, session templates, progression blocks.
 - Data:
   - `data/repository.ts`
-    - Seeds default `Workout A/B/C` session templates for otherwise-empty custom mesocycles and keeps Occam templates synced.
+    - Seeds focus-aware `Workout A/B/C` session templates for custom mesocycles (hypertrophy + strength blueprints) and keeps Occam templates synced when present.
   - `data/types.ts`
 - Hooks:
   - `hooks/usePeriodization.ts`

--- a/src/domains/account/hooks/useSettingsScreen.ts
+++ b/src/domains/account/hooks/useSettingsScreen.ts
@@ -7,7 +7,7 @@ import {
   fetchUserProfile,
   updateUserProfile,
 } from "@/domains/account/data/accountRepository";
-import { usePeriodization, type MesocycleProtocol } from "@/domains/periodization";
+import { usePeriodization } from "@/domains/periodization";
 import {
   resolveStoredModelForProvider,
   readLlmPreferences,
@@ -29,7 +29,6 @@ type WeightUnit = "kg" | "lb";
 const KG_TO_LB = 2.20462;
 const DEFAULT_PERIOD_DURATION_WEEKS = 6;
 const DEFAULT_PERIOD_GOAL_FOCUS: SessionFocus = "hypertrophy";
-const DEFAULT_PERIOD_PROTOCOL: MesocycleProtocol = "custom";
 
 const SESSION_FOCUS_LABELS: Record<SessionFocus, string> = {
   hypertrophy: "Hypertrophy",
@@ -62,13 +61,10 @@ const toKilograms = (weight: number, unit: WeightUnit): number => {
 };
 
 const buildPeriodName = (
-  focus: SessionFocus,
-  protocol: MesocycleProtocol
+  focus: SessionFocus
 ) => {
   const focusLabel = SESSION_FOCUS_LABELS[focus];
-  return protocol === "occams"
-    ? `Occam ${focusLabel} Block`
-    : `${focusLabel} Block`;
+  return `${focusLabel} Block`;
 };
 
 export const useSettingsScreen = () => {
@@ -111,8 +107,6 @@ export const useSettingsScreen = () => {
   const [periodGoalFocus, setPeriodGoalFocus] = useState<SessionFocus>(
     DEFAULT_PERIOD_GOAL_FOCUS
   );
-  const [periodProtocol, setPeriodProtocol] =
-    useState<MesocycleProtocol>(DEFAULT_PERIOD_PROTOCOL);
 
   const loadProfile = useCallback(async () => {
     if (!user) {
@@ -371,7 +365,6 @@ export const useSettingsScreen = () => {
     setPeriodGoalFocus(
       activeMesocycle?.goal_focus ?? DEFAULT_PERIOD_GOAL_FOCUS
     );
-    setPeriodProtocol(activeMesocycle?.protocol ?? DEFAULT_PERIOD_PROTOCOL);
   }, [activeProgram]);
 
   const handleOpenPeriodDialog = useCallback(() => {
@@ -398,9 +391,9 @@ export const useSettingsScreen = () => {
 
     try {
       const input = {
-        name: buildPeriodName(periodGoalFocus, periodProtocol),
+        name: buildPeriodName(periodGoalFocus),
         goal_focus: periodGoalFocus,
-        protocol: periodProtocol,
+        protocol: "custom",
         start_date: new Date().toISOString().split("T")[0],
         duration_weeks: duration,
       };
@@ -428,7 +421,6 @@ export const useSettingsScreen = () => {
     currentWorkout,
     periodDurationWeeks,
     periodGoalFocus,
-    periodProtocol,
     resetMesocycle,
     user,
   ]);
@@ -467,12 +459,10 @@ export const useSettingsScreen = () => {
     providerCredentialLastFour,
     periodDurationWeeks,
     periodGoalFocus,
-    periodProtocol,
     setBodyweight,
     setIsPeriodDialogOpen,
     setPeriodDurationWeeks,
     setPeriodGoalFocus,
-    setPeriodProtocol,
     triggerOnboarding,
     unitPref,
     userEmail: user?.email ?? null,

--- a/src/domains/account/ui/SettingsScreen.tsx
+++ b/src/domains/account/ui/SettingsScreen.tsx
@@ -28,7 +28,6 @@ import {
   llmProviderOptions,
   providerRequiresApiKey,
 } from "@/domains/guidance/data/llmPreferences";
-import type { MesocycleProtocol } from "@/domains/periodization";
 import { cn } from "@/lib/utils/cn";
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
@@ -71,14 +70,12 @@ const SettingsScreen = () => {
     llmProviderPref,
     periodDurationWeeks,
     periodGoalFocus,
-    periodProtocol,
     providerApiKeyDraft,
     providerCredentialLastFour,
     setBodyweight,
     setIsPeriodDialogOpen,
     setPeriodDurationWeeks,
     setPeriodGoalFocus,
-    setPeriodProtocol,
     triggerOnboarding,
     unitPref,
     userEmail,
@@ -112,7 +109,7 @@ const SettingsScreen = () => {
       ? `Week ${activeProgram.current_week} of ${
           activeProgram.mesocycle.duration_weeks
         } · ${formatSessionFocusLabel(activeProgram.mesocycle.goal_focus)} · ${
-          activeProgram.mesocycle.protocol === "occams" ? "Occam's" : "Custom"
+          "Focus Blueprint"
         }`
       : "No active period";
 
@@ -432,29 +429,7 @@ const SettingsScreen = () => {
               </Select>
             </div>
 
-            <div className="space-y-2">
-              <Label
-                htmlFor="settings-period-protocol"
-                className={FIELD_LABEL_CLASS}
-              >
-                Protocol
-              </Label>
-              <Select
-                value={periodProtocol}
-                onValueChange={value => setPeriodProtocol(value as MesocycleProtocol)}
-              >
-                <SelectTrigger
-                  id="settings-period-protocol"
-                  className="app-form-select h-12 rounded-[16px]"
-                >
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent className="stone-surface border-white/8 text-foreground">
-                  <SelectItem value="custom">Custom</SelectItem>
-                  <SelectItem value="occams">Occam&apos;s</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+            
 
             <div className="space-y-2">
               <Label

--- a/src/domains/fitness/hooks/useWorkoutScreen.ts
+++ b/src/domains/fitness/hooks/useWorkoutScreen.ts
@@ -4,7 +4,7 @@ import { useAppDispatch, useAppSelector } from "@/hooks/redux";
 import { useElapsedTime } from "@/hooks/useElapsedTime";
 import { toast } from "@/hooks/use-toast";
 import { usePeriodization } from "@/domains/periodization";
-import type { MesocycleProtocol, MesocycleSessionTemplate } from "@/domains/periodization";
+import type { MesocycleSessionTemplate } from "@/domains/periodization";
 import {
   selectCurrentWorkout,
   selectSessionFocus,
@@ -40,8 +40,6 @@ export const useWorkoutScreen = () => {
   const [mesocycleDurationWeeks, setMesocycleDurationWeeks] = useState(6);
   const [mesocycleGoalFocus, setMesocycleGoalFocus] =
     useState<SessionFocus>("hypertrophy");
-  const [mesocycleProtocol, setMesocycleProtocol] =
-    useState<MesocycleProtocol>("occams");
   const [mesocycleNotes, setMesocycleNotes] = useState("");
   const [showBlockBuilder, setShowBlockBuilder] = useState(false);
   const [isDiscardConfirmOpen, setIsDiscardConfirmOpen] = useState(false);
@@ -95,7 +93,7 @@ export const useWorkoutScreen = () => {
       await createMesocycle({
         name: mesocycleName.trim() || "Mesocycle",
         goal_focus: mesocycleGoalFocus,
-        protocol: mesocycleProtocol,
+        protocol: "custom",
         start_date: new Date().toISOString().split("T")[0],
         duration_weeks: duration,
         notes: mesocycleNotes.trim() || undefined,
@@ -204,7 +202,6 @@ export const useWorkoutScreen = () => {
     mesocycleName,
     mesocycleDurationWeeks,
     mesocycleGoalFocus,
-    mesocycleProtocol,
     mesocycleNotes,
     showBlockBuilder,
     isDiscardConfirmOpen,
@@ -220,7 +217,6 @@ export const useWorkoutScreen = () => {
     setMesocycleName,
     setMesocycleDurationWeeks,
     setMesocycleGoalFocus,
-    setMesocycleProtocol,
     setMesocycleNotes,
     setShowBlockBuilder,
     setIsDiscardConfirmOpen,

--- a/src/domains/fitness/ui/WorkoutScreen.tsx
+++ b/src/domains/fitness/ui/WorkoutScreen.tsx
@@ -24,7 +24,6 @@ import {
 } from "@/components/core/select";
 import { Textarea } from "@/components/core/textarea";
 import { useWorkoutScreen } from "@/domains/fitness/hooks/useWorkoutScreen";
-import type { MesocycleProtocol } from "@/domains/periodization";
 import SessionFocusSelector from "@/domains/fitness/ui/SessionFocusSelector";
 import WorkoutComponent from "@/domains/fitness/ui/WorkoutComponent";
 import {
@@ -60,7 +59,6 @@ const WorkoutScreen = () => {
     mesocycleName,
     mesocycleDurationWeeks,
     mesocycleGoalFocus,
-    mesocycleProtocol,
     mesocycleNotes,
     showBlockBuilder,
     isDiscardConfirmOpen,
@@ -76,7 +74,6 @@ const WorkoutScreen = () => {
     setMesocycleName,
     setMesocycleDurationWeeks,
     setMesocycleGoalFocus,
-    setMesocycleProtocol,
     setMesocycleNotes,
     setShowBlockBuilder,
     setIsDiscardConfirmOpen,
@@ -294,38 +291,7 @@ const WorkoutScreen = () => {
                         />
                       </div>
 
-                      <div className="space-y-2">
-                        <Label htmlFor="mesocycle-protocol" className={builderLabelClassName}>
-                          Protocol
-                        </Label>
-                        <Select
-                          value={mesocycleProtocol}
-                          onValueChange={value =>
-                            setMesocycleProtocol(value as MesocycleProtocol)
-                          }
-                        >
-                          <SelectTrigger
-                            id="mesocycle-protocol"
-                            className={builderSelectTriggerClassName}
-                          >
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent className={builderSelectContentClassName}>
-                            <SelectItem
-                              value="occams"
-                              className={builderSelectItemClassName}
-                            >
-                              Occam&apos;s Protocol
-                            </SelectItem>
-                            <SelectItem
-                              value="custom"
-                              className={builderSelectItemClassName}
-                            >
-                              Custom
-                            </SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
+                      
                     </div>
 
                     <div className="space-y-2">

--- a/src/domains/periodization/data/repository.ts
+++ b/src/domains/periodization/data/repository.ts
@@ -106,7 +106,7 @@ const OCCAMS_TEMPLATE: OccamsSessionTemplateDefinition[] = [
   },
 ];
 
-const CUSTOM_TEMPLATE: CustomSessionTemplateDefinition[] = [
+const HYPERTROPHY_TEMPLATE: CustomSessionTemplateDefinition[] = [
   {
     name: 'Workout A',
     sessionFocus: null,
@@ -213,6 +213,46 @@ const CUSTOM_TEMPLATE: CustomSessionTemplateDefinition[] = [
         loadIncrementKg: null,
         notes: null,
       },
+    ],
+  },
+];
+
+
+const STRENGTH_TEMPLATE: CustomSessionTemplateDefinition[] = [
+  {
+    name: 'Workout A',
+    sessionFocus: 'strength',
+    setsPerExercise: 3,
+    repRange: '3-5',
+    progressionRule: 'Add load when all sets hit 5 reps with clean technique and bar speed.',
+    exercises: [
+      { candidateNames: ['Squat', 'Back Squat'], targetSets: 3, targetReps: '3-5', loadIncrementKg: 2.5, notes: 'Primary lower-body strength lift.', presetEquipmentType: null, presetVariation: null },
+      { candidateNames: ['Bench Press'], targetSets: 3, targetReps: '3-5', loadIncrementKg: 2.5, notes: 'Primary horizontal press.', presetEquipmentType: null, presetVariation: null },
+      { candidateNames: ['Row'], targetSets: 3, targetReps: '5-8', loadIncrementKg: 2.5, notes: 'Heavy pull assistance.', presetEquipmentType: null, presetVariation: null },
+    ],
+  },
+  {
+    name: 'Workout B',
+    sessionFocus: 'strength',
+    setsPerExercise: 3,
+    repRange: '3-5',
+    progressionRule: 'Hold load until all primary sets reach top reps, then increase next exposure.',
+    exercises: [
+      { candidateNames: ['Deadlift', 'Romanian Deadlift'], targetSets: 3, targetReps: '3-5', loadIncrementKg: 5, notes: 'Primary hinge strength lift.', presetEquipmentType: null, presetVariation: null },
+      { candidateNames: ['Overhead Press'], targetSets: 3, targetReps: '3-5', loadIncrementKg: 2.5, notes: 'Primary vertical press.', presetEquipmentType: null, presetVariation: null },
+      { candidateNames: ['Pull-up', 'Pull Up', 'Pullups', 'Pull-Ups'], targetSets: 3, targetReps: '3-6', loadIncrementKg: 2.5, notes: 'Weighted if possible.', presetEquipmentType: null, presetVariation: null },
+    ],
+  },
+  {
+    name: 'Workout C',
+    sessionFocus: 'strength',
+    setsPerExercise: 3,
+    repRange: '3-5',
+    progressionRule: 'Use this day to reinforce weak points while keeping heavy intent.',
+    exercises: [
+      { candidateNames: ['Split Squat', 'Bulgarian Split Squat'], targetSets: 3, targetReps: '5-8', loadIncrementKg: 2.5, notes: 'Single-leg strength assistance.', presetEquipmentType: null, presetVariation: null },
+      { candidateNames: ['Bench Press'], targetSets: 3, targetReps: '3-5', loadIncrementKg: 2.5, notes: 'Secondary bench exposure.', presetEquipmentType: 'Barbell', presetVariation: 'Incline' },
+      { candidateNames: ['Wood Chop', 'Cable Wood Chop'], targetSets: 3, targetReps: '6-10', loadIncrementKg: 2.5, notes: 'Core strength and bracing.', presetEquipmentType: null, presetVariation: null },
     ],
   },
 ];
@@ -674,13 +714,15 @@ const ensureOccamsProtocolSessions = async (
 
 const ensureCustomProtocolSessions = async (
   mesocycleId: string,
+  goalFocus: SessionFocus,
   existingSessions: MesocycleSession[]
 ): Promise<void> => {
   const exercises = await fetchExerciseCatalog();
   const existingByName = new Map(existingSessions.map(session => [normalizeName(session.name), session]));
+  const template = goalFocus === "strength" ? STRENGTH_TEMPLATE : HYPERTROPHY_TEMPLATE;
 
-  for (let index = 0; index < CUSTOM_TEMPLATE.length; index += 1) {
-    const definition = CUSTOM_TEMPLATE[index];
+  for (let index = 0; index < template.length; index += 1) {
+    const definition = template[index];
     await upsertCustomProtocolSession(
       mesocycleId,
       index + 1,
@@ -714,7 +756,7 @@ export const getActiveMesocycleProgram = async (userId: string): Promise<ActiveM
     await ensureOccamsProtocolSessions(userId, mesocycle.id, sessions);
     sessions = await fetchSessionsForMesocycle(mesocycle.id);
   } else if (mesocycle.protocol === 'custom') {
-    await ensureCustomProtocolSessions(mesocycle.id, sessions);
+    await ensureCustomProtocolSessions(mesocycle.id, mesocycle.goal_focus, sessions);
     sessions = await fetchSessionsForMesocycle(mesocycle.id);
   }
 
@@ -800,7 +842,7 @@ const createMesocycleWithPreviousStatus = async (
   if (input.protocol === 'occams') {
     await ensureOccamsProtocolSessions(userId, createdMesocycle.id, []);
   } else if (input.protocol === 'custom') {
-    await ensureCustomProtocolSessions(createdMesocycle.id, []);
+    await ensureCustomProtocolSessions(createdMesocycle.id, createdMesocycle.goal_focus, []);
   }
 
   return createdMesocycle;


### PR DESCRIPTION
### Motivation

- Simplify periodization UX by removing protocol selection and treating blocks as focus-based blueprints (hypertrophy/strength) rather than separate protocol types. 
- Ensure new or reset mesocycles are seeded with appropriate default session templates based on the period goal focus. 

### Description

- Updated `CODEMAP.md` to document that custom mesocycles seed focus-aware `Workout A/B/C` templates and that Occam templates remain synced when present. 
- Removed usage and UI surfaces for `MesocycleProtocol` across hooks and components (`useSettingsScreen`, `SettingsScreen`, `useWorkoutScreen`, `WorkoutScreen`), including the protocol select controls and related state. 
- Changed mesocycle creation/reset flows to always set `protocol: "custom"` and to derive the seeded sessions from `goal_focus` by adding `HYPERTROPHY_TEMPLATE` and `STRENGTH_TEMPLATE` and updating `ensureCustomProtocolSessions` to accept a `goalFocus` and pick the appropriate template. 
- Updated `getActiveMesocycleProgram` and `createMesocycle` to pass `mesocycle.goal_focus` into the custom-session seeding path and adjusted period summary text to show a "Focus Blueprint" label. 

### Testing

- Ran TypeScript typecheck and the project test suite (`pnpm build`/`tsc` and `pnpm test`) locally and confirmed both completed without errors. 
- Verified the application builds and the modified period creation and seeding code paths execute in manual local runs of the period creation flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9baa9e608832c9842860b07f409eb)