### PR TITLE
Fix exercise picker double-tap and enforce stone popover styling

### DIFF
--- a/src/domains/fitness/ui/ExerciseSelector.tsx
+++ b/src/domains/fitness/ui/ExerciseSelector.tsx
@@ -249,9 +249,6 @@ const ExerciseSelector = ({
                     onPointerDown={() => handlePointerDown(exercise)}
                     onPointerUp={clearLongPressTimer}
                     onPointerLeave={clearLongPressTimer}
-                    onTouchStart={() => handlePointerDown(exercise)}
-                    onTouchEnd={clearLongPressTimer}
-                    onTouchCancel={clearLongPressTimer}
                     onContextMenu={(e) => {
                       e.preventDefault();
                       setExerciseToDelete(exercise);

--- a/src/domains/fitness/ui/workoutSelectionStyles.ts
+++ b/src/domains/fitness/ui/workoutSelectionStyles.ts
@@ -3,13 +3,13 @@ export const workoutPanelClassName =
 
 export const workoutDialogClassName = `${workoutPanelClassName} rounded-[28px] p-5 sm:max-w-md`;
 
-export const workoutPopoverClassName = `stone-surface w-[220px] rounded-[18px] p-2 text-foreground`;
+export const workoutPopoverClassName = `stone-surface w-[220px] rounded-[18px] border border-white/[0.08] bg-[var(--stone-surface)] p-2 text-foreground shadow-[0_16px_40px_-24px_rgba(0,0,0,0.72)]`;
 
 export const workoutMenuInputClassName =
   "stone-inset h-11 rounded-[16px] text-sm text-foreground shadow-none placeholder:text-muted-foreground/80 focus-visible:ring-0 focus-visible:ring-offset-0";
 
 export const workoutMenuOptionClassName =
-  "h-10 w-full justify-start rounded-[12px] border border-transparent bg-transparent px-3 text-[13px] font-medium text-foreground/88 hover:bg-white/[0.03] hover:text-foreground focus-visible:bg-white/[0.03] focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=open]:bg-transparent data-[state=open]:text-foreground disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-foreground/88";
+  "h-10 w-full justify-start rounded-[12px] border border-transparent bg-[var(--stone-surface)] px-3 text-[13px] font-medium text-foreground/88 hover:bg-white/[0.03] hover:text-foreground focus-visible:bg-white/[0.03] focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=open]:bg-[var(--stone-surface)] data-[state=open]:text-foreground disabled:opacity-40 disabled:hover:bg-[var(--stone-surface)] disabled:hover:text-foreground/88";
 
 export const workoutMenuSectionClassName =
   "stone-surface rounded-[20px] p-3";


### PR DESCRIPTION
### Motivation
- Prevent mobile/double-tap selection where the exercise picker required two presses by removing conflicting touch event paths so selection uses pointer events only.
- Fix a visual regression where equipment/variation selector popovers showed a plain/clean background by forcing the stone surface, border, and shadow in the popover styling.

### Description
- Removed `onTouchStart`, `onTouchEnd`, and `onTouchCancel` handlers from exercise list items so taps rely on the existing pointer event handlers in `src/domains/fitness/ui/ExerciseSelector.tsx`.
- Hardened popover surface styling by updating `workoutPopoverClassName` to include an explicit stone background, border, and shadow in `src/domains/fitness/ui/workoutSelectionStyles.ts`.
- Updated `workoutMenuOptionClassName` in `src/domains/fitness/ui/workoutSelectionStyles.ts` to keep option rows on the stone surface for normal, open, and disabled states to avoid unstyled/clean background leaks.

### Testing
- Ran `npm run build` which completed successfully.
- Ran `npm run lint` which completed and reported the existing baseline warnings only (no new lint errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0d775680832cabf5973e2d5e794a)