### PR TITLE
Fix exercise selector tap behavior and variation/equipment menu background styling

### DIFF
--- a/src/domains/fitness/ui/ExerciseSelector.tsx
+++ b/src/domains/fitness/ui/ExerciseSelector.tsx
@@ -177,8 +177,8 @@ const ExerciseSelector = ({
           className={cn(
             workoutDialogClassName,
             isSearchFocused
-              ? "!top-4 !translate-y-0 sm:!top-[50%] sm:!translate-y-[-50%]"
-              : "!left-0 !top-0 !h-[100dvh] !w-screen !max-w-none !translate-x-0 !translate-y-0 rounded-none p-4 sm:!left-[50%] sm:!top-[50%] sm:!h-auto sm:!w-full sm:!max-w-md sm:!translate-x-[-50%] sm:!translate-y-[-50%] sm:rounded-[28px] sm:p-5"
+              ? "!left-0 !top-0 !h-[100dvh] !w-screen !max-w-none !translate-x-0 !translate-y-0 rounded-none p-4 sm:!left-[50%] sm:!top-[50%] sm:!h-auto sm:!w-full sm:!max-w-md sm:!translate-x-[-50%] sm:!translate-y-[-50%] sm:rounded-[28px] sm:p-5"
+              : "!top-4 !translate-y-0 sm:!top-[50%] sm:!translate-y-[-50%]"
           )}
           onOpenAutoFocus={(e) => e.preventDefault()}
           onInteractOutside={(e) => {
@@ -255,7 +255,7 @@ const ExerciseSelector = ({
                       setIsConfirmDeleteDialogOpen(true);
                     }}
                     disabled={exercise.id === disabledExerciseId}
-                    className={`${workoutMenuOptionClassName} h-11 select-none justify-start px-4 text-sm ${
+                    className={`${workoutMenuOptionClassName} !bg-[var(--stone-surface)] h-11 select-none justify-start px-4 text-sm ${
                       exercise.id === disabledExerciseId ? "bg-white/[0.03]" : ""
                     }`}
                     style={{ WebkitTouchCallout: 'none' }}

--- a/src/domains/fitness/ui/workoutSelectionStyles.ts
+++ b/src/domains/fitness/ui/workoutSelectionStyles.ts
@@ -9,7 +9,7 @@ export const workoutMenuInputClassName =
   "stone-inset h-11 rounded-[16px] text-sm text-foreground shadow-none placeholder:text-muted-foreground/80 focus-visible:ring-0 focus-visible:ring-offset-0";
 
 export const workoutMenuOptionClassName =
-  "h-10 w-full justify-start rounded-[12px] border border-transparent bg-[var(--stone-surface)] px-3 text-[13px] font-medium text-foreground/88 hover:bg-white/[0.03] hover:text-foreground focus-visible:bg-white/[0.03] focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=open]:bg-[var(--stone-surface)] data-[state=open]:text-foreground disabled:opacity-40 disabled:hover:bg-[var(--stone-surface)] disabled:hover:text-foreground/88";
+  "h-10 w-full justify-start rounded-[12px] border border-transparent !bg-[var(--stone-surface)] px-3 text-[13px] font-medium text-foreground/88 hover:!bg-white/[0.03] hover:text-foreground focus-visible:!bg-white/[0.03] focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=open]:!bg-[var(--stone-surface)] data-[state=open]:text-foreground disabled:opacity-40 disabled:hover:!bg-[var(--stone-surface)] disabled:hover:text-foreground/88";
 
 export const workoutMenuSectionClassName =
   "stone-surface rounded-[20px] p-3";


### PR DESCRIPTION
### Motivation
- Stop the exercise selector from snapping layouts and swallowing the first tap when the search input is focused so users can select an exercise with a single tap. 
- Prevent legacy/accent theme colors (green) from leaking into variation and equipment option rows by making menu backgrounds explicit and resistant to inherited accent styles.

### Description
- Corrected the `isSearchFocused` layout conditional in `src/domains/fitness/ui/ExerciseSelector.tsx` so the dialog keeps the intended mobile/fullscreen layout while the search input is focused. 
- Hardened menu option backgrounds in `src/domains/fitness/ui/workoutSelectionStyles.ts` by adding explicit `!bg-[var(--stone-surface)]` / `!bg-*` overrides for default/hover/focus/open/disabled states. 
- Applied the explicit stone-surface background guard to exercise list rows in `src/domains/fitness/ui/ExerciseSelector.tsx` so rows do not inherit legacy accent backgrounds.

### Testing
- Ran `npm run build` successfully; production build completed without errors. 
- Ran `npm run lint` successfully; existing baseline warnings remain but there are no new lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb16978ec832c8399495af34cc3cc)