### PR TITLE
Keep reps placeholder state when only weight changes

### DIFF
--- a/src/domains/fitness/hooks/useSet.ts
+++ b/src/domains/fitness/hooks/useSet.ts
@@ -318,10 +318,11 @@ export const useSet = ({
                 }
             } else {
                 const parsedRepsVal = parseInt(localReps);
+                const isRepsInputEmpty = localReps.trim() === '';
                 const nextRepsValue =
                     field === 'reps'
                         ? (Number.isNaN(parsedRepsVal) ? null : parsedRepsVal)
-                        : set.reps;
+                        : (isRepsInputEmpty ? null : set.reps);
                 const updatePayload: StrengthSetUpdatePayload = {
                     ...baseUpdatePayload,
                     reps: nextRepsValue,


### PR DESCRIPTION
### Motivation
- Fix a UX bug where editing the weight input would make the reps field look filled (white) even when the user never touched reps. 
- Reps should remain in the placeholder/grey state unless the user explicitly changes the reps value.

### Description
- Adjusted blur/update logic in `src/domains/fitness/hooks/useSet.ts` to treat an empty `localReps` string as `null` when weight is the only field that changed. 
- Added `isRepsInputEmpty` and updated `nextRepsValue` calculation so untouched reps are preserved as `null` instead of using the existing set value. 
- This prevents an unnecessary `updateSet` payload from treating reps as filled when the user only edited weight.

### Testing
- Ran `npm run build` and the build completed successfully. 
- Ran `npm run lint` and lint passed with the existing baseline warnings (8 warnings, 0 errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e8b9d90c4832ca6dd16eb53b07813)