### PR TITLE
Unify loading: central QueryClient defaults, app skeleton, and onboarding split

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -6,7 +6,7 @@ This file is the fast operational map for agents and future sessions. It is not 
 
 - Architecture rename is complete: use `ui / hooks / data`, not `view / controller / model`.
 - `npm run build` passes.
-- `npm run lint` currently reports 8 warnings and 0 errors.
+- `npm run lint` currently reports warnings but no errors (react-refresh export warnings in shared providers/components).
 - There is no test script in `package.json`.
 - Do not run `npm run build` and `npm run lint` at the same time. Vite can create transient `vite.config.ts.timestamp-*.mjs` files that make ESLint fail with `ENOENT`.
 - Public routes do not load Redux persistence or the protected shell up front; `App.tsx` lazy-loads the protected app shell after route match.
@@ -89,8 +89,8 @@ Pages should stay thin wrappers around domain screens.
 ### Auth
 
 - `src/state/auth/AuthProvider.tsx`
-  - Single source of truth for `session`, `user`, `loading`, and onboarding trigger state.
-  - Also owns onboarding completeness checks and renders `OnboardingDialog`.
+  - Single source of truth for `session`, `user`, and auth identity readiness (`loading`).
+  - Renders `OnboardingDialog`, while onboarding completeness checks are delegated to `src/state/auth/hooks/useOnboardingPrompt.ts`.
 - `src/domains/account/ui/AuthForm.tsx`
   - Still imports Supabase directly only for the Supabase Auth widget.
   - Exposes email self-signup by default for public account creation.
@@ -99,6 +99,8 @@ Pages should stay thin wrappers around domain screens.
 ### Server State
 
 - React Query is the canonical server-state layer.
+- QueryClient defaults are centralized in `src/lib/query/loadingPolicies.ts`.
+- Domain hooks can use `createAppQueryOptions` from `src/lib/query/loadingPolicies.ts` to express loading intent (`static` / `session` / `background`).
 - Query creation mostly lives in domain hooks.
 - Repository functions in `src/domains/*/data` are the fetch/mutation layer.
 
@@ -122,6 +124,7 @@ The workout flow is the main Redux-heavy area. Most other features should prefer
 - Hooks:
   - `hooks/useOnboarding.ts`
   - `hooks/useSettingsScreen.ts`
+  - `src/state/auth/hooks/useOnboardingPrompt.ts` (auth-adjacent onboarding completeness trigger)
     - Owns profile preferences, coach provider preferences, and active training-period reset/create from Settings.
 - UI:
   - `ui/AuthForm.tsx`

--- a/src/components/layout/MainAppLayout.tsx
+++ b/src/components/layout/MainAppLayout.tsx
@@ -1,4 +1,5 @@
 import { Component, Suspense, lazy, type ReactNode } from "react";
+import AppScreenSkeleton from "@/components/loading/AppScreenSkeleton";
 import { Routes, Route, useLocation } from "react-router-dom";
 import { Plus } from "lucide-react";
 
@@ -93,11 +94,6 @@ const Coach = lazyWithRetry(() => import("@/pages/Coach"));
 const Settings = lazyWithRetry(() => import("@/pages/Settings"));
 const NotFound = lazyWithRetry(() => import("@/pages/NotFound"));
 
-const RouteFallback = () => (
-  <div className="app-page">
-    <div className="stone-surface min-h-[16rem] animate-pulse rounded-[26px]" />
-  </div>
-);
 
 const MainAppLayout = () => {
   useOfflineWorkoutSync();
@@ -132,7 +128,7 @@ const MainAppLayout = () => {
       </div>
       <SidebarInset className="app-shell">
         <RouteErrorBoundary resetKey={location.key}>
-          <Suspense fallback={<RouteFallback />}>
+          <Suspense fallback={<AppScreenSkeleton />}>
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/workout" element={<Workout />} />
@@ -175,7 +171,7 @@ const MainAppLayout = () => {
         )}
 
         {isProteinModalOpen ? (
-          <Suspense fallback={null}>
+          <Suspense fallback={<div className="sr-only">Loading protein dialog</div>}>
             <ProteinLogging
               isOpen={isProteinModalOpen}
               onClose={() => setIsProteinModalOpen(false)}
@@ -185,7 +181,7 @@ const MainAppLayout = () => {
         ) : null}
 
         {isSunExposureModalOpen ? (
-          <Suspense fallback={null}>
+          <Suspense fallback={<div className="sr-only">Loading sun exposure dialog</div>}>
             <SunExposureLogging
               isOpen={isSunExposureModalOpen}
               onClose={() => setIsSunExposureModalOpen(false)}
@@ -195,7 +191,7 @@ const MainAppLayout = () => {
         ) : null}
 
         {isAddExerciseDialogOpen ? (
-          <Suspense fallback={null}>
+          <Suspense fallback={<div className="sr-only">Loading exercise dialog</div>}>
             <AddSingleExerciseDialog
               open={isAddExerciseDialogOpen}
               onOpenChange={setIsAddExerciseDialogOpen}

--- a/src/components/layout/ProtectedRoute.tsx
+++ b/src/components/layout/ProtectedRoute.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useEffect } from 'react';
 import { useAuth } from '@/state/auth/AuthProvider';
 import { useNavigate } from 'react-router-dom';
+import AppScreenSkeleton from '@/components/loading/AppScreenSkeleton';
 
 interface ProtectedRouteProps {
   children: ReactNode;
@@ -11,24 +12,20 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // If loading is finished and there's no session, redirect to login.
     if (!loading && !session) {
-      navigate('/login', { replace: true }); // Use replace to avoid login page in history
+      navigate('/login', { replace: true });
     }
   }, [session, loading, navigate]);
 
-  // While loading, show nothing or a loading indicator
   if (loading) {
-    return <div className="min-h-screen flex items-center justify-center">Loading...</div>; // Or a spinner
+    return <AppScreenSkeleton />;
   }
 
-  // If there's a session, render the children (the protected content)
   if (session) {
     return <>{children}</>;
   }
 
-  // If no session and not loading (should have been redirected), return null
   return null;
 };
 
-export default ProtectedRoute; 
+export default ProtectedRoute;

--- a/src/components/loading/AppScreenSkeleton.tsx
+++ b/src/components/loading/AppScreenSkeleton.tsx
@@ -1,0 +1,7 @@
+const AppScreenSkeleton = () => (
+  <div className="app-page" aria-busy="true" aria-live="polite">
+    <div className="stone-surface min-h-[16rem] animate-pulse rounded-[26px]" />
+  </div>
+);
+
+export default AppScreenSkeleton;

--- a/src/lib/query/loadingPolicies.ts
+++ b/src/lib/query/loadingPolicies.ts
@@ -1,0 +1,47 @@
+import type { DefaultOptions, QueryKey, UseQueryOptions } from '@tanstack/react-query';
+
+export type LoadingIntent = 'static' | 'session' | 'background';
+
+const MINUTE = 60 * 1000;
+
+const staleTimeByIntent: Record<LoadingIntent, number> = {
+  static: Infinity,
+  session: 5 * MINUTE,
+  background: 60 * 1000,
+};
+
+export const queryClientDefaultOptions: DefaultOptions = {
+  queries: {
+    staleTime: 60 * 1000,
+    gcTime: 30 * MINUTE,
+    retry: 1,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: true,
+  },
+};
+
+type AppQueryOptionsInput<
+  TQueryFnData,
+  TError = Error,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'queryKey' | 'queryFn'> & {
+  intent?: LoadingIntent;
+};
+
+export const createAppQueryOptions = <
+  TQueryFnData,
+  TError = Error,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: AppQueryOptionsInput<TQueryFnData, TError, TData, TQueryKey> = {}
+): AppQueryOptionsInput<TQueryFnData, TError, TData, TQueryKey> => {
+  const { intent = 'background', staleTime, gcTime, ...rest } = options;
+
+  return {
+    staleTime: staleTime ?? staleTimeByIntent[intent],
+    gcTime: gcTime ?? queryClientDefaultOptions.queries?.gcTime,
+    ...rest,
+  };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,10 +3,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App.tsx'
 import './index.css'
 import { AuthProvider } from './state/auth/AuthProvider'
+import { queryClientDefaultOptions } from './lib/query/loadingPolicies'
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: queryClientDefaultOptions,
+})
 
-createRoot(document.getElementById("root")!).render(
+createRoot(document.getElementById('root')!).render(
   <QueryClientProvider client={queryClient}>
     <AuthProvider>
       <App />

--- a/src/state/auth/AuthProvider.tsx
+++ b/src/state/auth/AuthProvider.tsx
@@ -4,14 +4,11 @@ import React, {
   useEffect,
   useState,
   ReactNode,
-} from "react";
-import { Session, User } from "@supabase/supabase-js";
-import { supabase } from "@/lib/integrations/supabase/client";
-import { OnboardingDialog } from "@/domains/account/ui/OnboardingDialog";
-import { fetchUserProfile, type ProfileRow } from "@/domains/account/data/accountRepository";
-import type { Database } from '@/lib/integrations/supabase/types';
-
-
+} from 'react';
+import { Session, User } from '@supabase/supabase-js';
+import { supabase } from '@/lib/integrations/supabase/client';
+import { OnboardingDialog } from '@/domains/account/ui/OnboardingDialog';
+import { useOnboardingPrompt } from '@/state/auth/hooks/useOnboardingPrompt';
 
 type AuthContextType = {
   session: Session | null;
@@ -30,165 +27,72 @@ type AuthProviderProps = {
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true); // Start as true until initial check is done
-  const [showOnboarding, setShowOnboarding] = useState(false);
-  const [profileChecked, setProfileChecked] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  const {
+    showOnboarding,
+    setShowOnboarding,
+    triggerOnboarding,
+    markOnboardingComplete,
+  } = useOnboardingPrompt(user, loading);
 
   useEffect(() => {
-    // Attempt to get the session initially
     supabase.auth
       .getSession()
-      .then(({ data: { session } }) => {
-        setSession(session);
-        setUser(session?.user ?? null);
-        setLoading(false); // Initial check complete
+      .then(({ data: { session: initialSession } }) => {
+        setSession(initialSession);
+        setUser(initialSession?.user ?? null);
+        setLoading(false);
       })
-      .catch((error) => {
-        // console.error("Error getting initial session:", error);
-        setLoading(false); // Still finish loading even if there's an error
+      .catch(() => {
+        setLoading(false);
       });
 
-    // Listen for auth state changes
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      // console.log("Auth state changed:", _event, session);
-      setSession(session);
-      setUser(session?.user ?? null);
-      if (_event !== 'INITIAL_SESSION') {
-        setLoading(false); // Ensure loading is false after subsequent changes
+    } = supabase.auth.onAuthStateChange((event, nextSession) => {
+      setSession(nextSession);
+      setUser(nextSession?.user ?? null);
+      if (event !== 'INITIAL_SESSION') {
+        setLoading(false);
       }
     });
 
-    // Cleanup subscription on unmount
     return () => {
       subscription?.unsubscribe();
     };
   }, []);
 
-  // Effect to check profile and trigger onboarding if needed
-  useEffect(() => {
-    // Only run if we have a user, initial auth loading is done, and we haven't checked the profile yet
-    if (user && !loading && !profileChecked) {
-      const checkProfile = async () => {
-        console.log("Checking user profile for onboarding completion...");
-        try {
-          const profileData = await fetchUserProfile(user.id);
-
-          // Check if any required fields are missing (null or undefined)
-          const needsOnboarding =
-            !profileData || // No profile row exists
-            profileData.age === null ||
-            profileData.height === null ||
-            profileData.weight === null ||
-            profileData.focus === null ||
-            profileData.preferred_weight_unit === null ||
-            profileData.preferred_height_unit === null ||
-            profileData.preferred_distance_unit === null;
-
-          if (needsOnboarding) {
-            console.log("User needs onboarding.");
-            setShowOnboarding(true);
-          } else {
-            console.log("User has completed onboarding.");
-          }
-        } catch (err) {
-          console.error("Unexpected error during profile check:", err);
-        }
-        setProfileChecked(true); // Mark profile as checked, even if there was an error
-      };
-
-      checkProfile();
-    }
-
-    // Reset profile check if user logs out
-    if (!user) {
-      setProfileChecked(false);
-      setShowOnboarding(false); // Ensure dialog is closed on logout
-    }
-
-  }, [user, loading, profileChecked]);
-
-  // Function to manually trigger the onboarding dialog
-  const triggerOnboarding = () => {
-    console.log("Manually triggering onboarding flow...");
-    setProfileChecked(false); // Reset check to allow dialog to show even if profile was previously complete
-    setShowOnboarding(true);
-  };
-
   const signOut = async () => {
     setLoading(true);
-    const { error } = await supabase.auth.signOut();
-    if (error) {
-      // console.error("Error signing out:", error);
-      // Optionally handle sign-out error (e.g., show a toast)
-    }
-    // State will be updated by onAuthStateChange listener
+    await supabase.auth.signOut();
     setLoading(false);
   };
 
-  const value = {
-    session,
-    user,
-    loading,
-    signOut,
-    triggerOnboarding,
-  };
-
-  // Don't render children until the initial session check is complete
   return (
-    <AuthContext.Provider value={value}>
-      {/* {!loading && children}  // Option 1: Render children only when not loading */}
-      {children}             {/* Option 2: Render children always, handle loading state in components */}
-
-      {/* Render Onboarding Dialog conditionally */}
+    <AuthContext.Provider
+      value={{
+        session,
+        user,
+        loading,
+        signOut,
+        triggerOnboarding,
+      }}
+    >
+      {children}
       <OnboardingDialog
         open={showOnboarding}
-        onOpenChange={setShowOnboarding} // Allow closing via overlay click etc.
-        onComplete={() => {
-          setShowOnboarding(false); // Close dialog on successful completion
-          setProfileChecked(true); // Mark as checked since they just completed it
-          // Optionally: re-fetch profile data if needed elsewhere immediately
-        }}
+        onOpenChange={setShowOnboarding}
+        onComplete={markOnboardingComplete}
       />
     </AuthContext.Provider>
   );
 };
 
-// Custom hook to use the Auth context
 export const useAuth = (): AuthContextType => {
   const context = useContext(AuthContext);
   if (context === undefined) {
-    throw new Error("useAuth must be used within an AuthProvider");
+    throw new Error('useAuth must be used within an AuthProvider');
   }
   return context;
 };
-
-// Optional: Helper component to require authentication
-type ProtectedRouteProps = {
-  children: ReactNode;
-  // You might add roles or permissions here later
-};
-
-// export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
-//   const { session, loading } = useAuth();
-//   const navigate = useNavigate(); // Assuming react-router-dom
-
-//   useEffect(() => {
-//     if (!loading && !session) {
-//       navigate('/login'); // Redirect to login if not authenticated after loading
-//     }
-//   }, [session, loading, navigate]);
-
-//   if (loading) {
-//     // Optional: Render a loading spinner or skeleton screen
-//     return <div>Loading...</div>;
-//   }
-
-//   if (!session) {
-//     // Should be redirected by useEffect, but return null as a fallback
-//     return null;
-//   }
-
-//   return <>{children}</>;
-// }; 

--- a/src/state/auth/hooks/useOnboardingPrompt.ts
+++ b/src/state/auth/hooks/useOnboardingPrompt.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+
+import { fetchUserProfile } from '@/domains/account/data/accountRepository';
+import type { User } from '@supabase/supabase-js';
+
+const hasIncompleteProfile = (profileData: Awaited<ReturnType<typeof fetchUserProfile>>) => {
+  if (!profileData) return true;
+
+  return (
+    profileData.age === null ||
+    profileData.height === null ||
+    profileData.weight === null ||
+    profileData.focus === null ||
+    profileData.preferred_weight_unit === null ||
+    profileData.preferred_height_unit === null ||
+    profileData.preferred_distance_unit === null
+  );
+};
+
+export const useOnboardingPrompt = (user: User | null, authLoading: boolean) => {
+  const [showOnboarding, setShowOnboarding] = useState(false);
+  const [hasCheckedProfile, setHasCheckedProfile] = useState(false);
+
+  useEffect(() => {
+    if (!user) {
+      setHasCheckedProfile(false);
+      setShowOnboarding(false);
+      return;
+    }
+
+    if (authLoading || hasCheckedProfile) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const checkProfile = async () => {
+      try {
+        const profileData = await fetchUserProfile(user.id);
+        if (!cancelled && hasIncompleteProfile(profileData)) {
+          setShowOnboarding(true);
+        }
+      } catch (error) {
+        console.error('Unexpected error during profile check:', error);
+      } finally {
+        if (!cancelled) {
+          setHasCheckedProfile(true);
+        }
+      }
+    };
+
+    void checkProfile();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, hasCheckedProfile, user]);
+
+  const triggerOnboarding = () => {
+    setHasCheckedProfile(false);
+    setShowOnboarding(true);
+  };
+
+  const markOnboardingComplete = () => {
+    setShowOnboarding(false);
+    setHasCheckedProfile(true);
+  };
+
+  return {
+    showOnboarding,
+    setShowOnboarding,
+    triggerOnboarding,
+    markOnboardingComplete,
+  };
+};


### PR DESCRIPTION
### Motivation
- Loading behavior was inconsistent across pages due to ad-hoc query options and mixed auth/onboarding responsibilities causing full-screen stalls and visual jitter. 
- The app needed a shared loading contract and a single screen-level skeleton to avoid blanking the protected shell on route transitions. 
- Onboarding profile checks should not block auth identity readiness or the protected shell render. 

### Description
- Add centralized React Query defaults and an intent-based helper in `src/lib/query/loadingPolicies.ts` (`queryClientDefaultOptions`, `createAppQueryOptions`) and wire them into bootstrap via `src/main.tsx`. 
- Add a shared `AppScreenSkeleton` primitive at `src/components/loading/AppScreenSkeleton.tsx` and use it as the `Suspense` fallback for `MainAppLayout` and as the `ProtectedRoute` loading UI, replacing plain `Loading...`. 
- Reduce empty/null lazy fallbacks for dialogs by providing screen-reader-safe placeholders in `src/components/layout/MainAppLayout.tsx`. 
- Decouple onboarding completeness checks from `AuthProvider` by adding `src/state/auth/hooks/useOnboardingPrompt.ts` and updating `src/state/auth/AuthProvider.tsx` to only own identity readiness while delegating onboarding prompting; update `CODEMAP.md` to reflect the new seams. 

### Testing
- Ran `npm run build`, which completed successfully. 
- Ran `npm run lint`, which completed with the existing baseline warnings (8 warnings, 0 errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f2414e718832ca94cd41f40e90680)