### PR TITLE
Refactor workout-start orchestration to reduce core-flow duplication

### DIFF
--- a/src/domains/dashboard/hooks/useHomeDashboard.ts
+++ b/src/domains/dashboard/hooks/useHomeDashboard.ts
@@ -3,9 +3,12 @@ import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 
 import { buildExercisesFromSessionTemplate } from "@/domains/fitness/data/workoutScreen";
+import {
+  createBaseWorkoutStartPayload,
+  createProgramWorkoutStartPayload,
+} from "@/domains/fitness/data/workoutStartPayload";
 import { useTriad, useHabitCompletions } from "@/domains/habits";
 import { usePeriodization } from "@/domains/periodization";
-import type { SessionFocus } from "@/lib/types/workout";
 import { useAppDispatch, useAppSelector } from "@/hooks/redux";
 import { useAuth } from "@/state/auth/AuthProvider";
 import {
@@ -266,26 +269,26 @@ export const useHomeDashboard = () => {
 
     if (nextSession && activeProgram) {
       dispatch(
-        startWorkoutAction({
-          ownerUserId: user?.id ?? null,
-          sessionFocus: (nextSession.session_focus ??
-            activeProgram.mesocycle.goal_focus) as SessionFocus,
-          mesocycleId: activeProgram.mesocycle.id,
-          mesocycleSessionId: nextSession.id,
-          mesocycleWeek: activeProgram.current_week,
-          mesocycleProtocol: activeProgram.mesocycle.protocol,
-          initialExercises: await buildExercisesFromSessionTemplate(nextSession, userId ?? ""),
-        })
+        startWorkoutAction(
+          createProgramWorkoutStartPayload({
+            ownerUserId: user?.id ?? null,
+            activeProgram,
+            sessionTemplate: nextSession,
+            initialExercises: await buildExercisesFromSessionTemplate(nextSession, userId ?? ""),
+          })
+        )
       );
       navigate("/workout");
       return;
     }
 
     dispatch(
-      startWorkoutAction({
-        ownerUserId: user?.id ?? null,
-        sessionFocus: activeProgram?.mesocycle.goal_focus,
-      })
+      startWorkoutAction(
+        createBaseWorkoutStartPayload({
+          ownerUserId: user?.id ?? null,
+          sessionFocus: activeProgram?.mesocycle.goal_focus,
+        })
+      )
     );
     navigate("/workout");
   };

--- a/src/domains/fitness/data/workoutStartPayload.ts
+++ b/src/domains/fitness/data/workoutStartPayload.ts
@@ -1,0 +1,45 @@
+import type { MesocycleSessionTemplate } from "@/domains/periodization";
+import type { SessionFocus } from "@/lib/types/workout";
+
+interface BaseStartPayload {
+  ownerUserId: string | null;
+  sessionFocus?: SessionFocus;
+}
+
+interface ProgramSessionInput {
+  ownerUserId: string | null;
+  activeProgram: {
+    mesocycle: {
+      id: string;
+      goal_focus: SessionFocus;
+      protocol: string;
+    };
+    current_week: number;
+  };
+  sessionTemplate: Pick<MesocycleSessionTemplate, "id" | "session_focus">;
+  initialExercises?: unknown[];
+}
+
+export const createBaseWorkoutStartPayload = ({
+  ownerUserId,
+  sessionFocus,
+}: BaseStartPayload) => ({
+  ownerUserId,
+  sessionFocus,
+});
+
+export const createProgramWorkoutStartPayload = ({
+  ownerUserId,
+  activeProgram,
+  sessionTemplate,
+  initialExercises,
+}: ProgramSessionInput) => ({
+  ownerUserId,
+  sessionFocus: (sessionTemplate.session_focus ??
+    activeProgram.mesocycle.goal_focus) as SessionFocus,
+  mesocycleId: activeProgram.mesocycle.id,
+  mesocycleSessionId: sessionTemplate.id,
+  mesocycleWeek: activeProgram.current_week,
+  mesocycleProtocol: activeProgram.mesocycle.protocol,
+  ...(initialExercises ? { initialExercises } : {}),
+});

--- a/src/domains/fitness/hooks/useWorkoutScreen.ts
+++ b/src/domains/fitness/hooks/useWorkoutScreen.ts
@@ -14,6 +14,10 @@ import { useAuth } from "@/state/auth/AuthProvider";
 import { useWorkoutPersistence } from "@/domains/fitness/hooks/useWorkout";
 import type { SessionFocus } from "@/lib/types/workout";
 import { buildExercisesFromSessionTemplate } from "@/domains/fitness/data/workoutScreen";
+import {
+  createBaseWorkoutStartPayload,
+  createProgramWorkoutStartPayload,
+} from "@/domains/fitness/data/workoutStartPayload";
 
 export const useWorkoutScreen = () => {
   const dispatch = useAppDispatch();
@@ -56,10 +60,12 @@ export const useWorkoutScreen = () => {
 
   const handleStartWorkout = () => {
     dispatch(
-      startWorkoutAction({
-        ownerUserId: user?.id ?? null,
-        sessionFocus: selectedFocus || undefined,
-      })
+      startWorkoutAction(
+        createBaseWorkoutStartPayload({
+          ownerUserId: user?.id ?? null,
+          sessionFocus: selectedFocus || undefined,
+        })
+      )
     );
   };
 
@@ -104,16 +110,14 @@ export const useWorkoutScreen = () => {
     if (!activeProgram) return;
 
     dispatch(
-      startWorkoutAction({
-        ownerUserId: user?.id ?? null,
-        sessionFocus: (sessionTemplate.session_focus ??
-          activeProgram.mesocycle.goal_focus) as SessionFocus,
-        mesocycleId: activeProgram.mesocycle.id,
-        mesocycleSessionId: sessionTemplate.id,
-        mesocycleWeek: activeProgram.current_week,
-        mesocycleProtocol: activeProgram.mesocycle.protocol,
-        initialExercises: await buildExercisesFromSessionTemplate(sessionTemplate, user?.id ?? ""),
-      })
+      startWorkoutAction(
+        createProgramWorkoutStartPayload({
+          ownerUserId: user?.id ?? null,
+          activeProgram,
+          sessionTemplate,
+          initialExercises: await buildExercisesFromSessionTemplate(sessionTemplate, user?.id ?? ""),
+        })
+      )
     );
   };
 


### PR DESCRIPTION
### Motivation
- The workout-start payload construction was duplicated across core entrypoints, increasing maintenance cost and risk of behavioral drift. 
- Centralize payload assembly into the data layer so both dashboard- and screen-driven starts share a single source of truth while preserving existing behavior.

### Description
- Added `src/domains/fitness/data/workoutStartPayload.ts` which exports `createBaseWorkoutStartPayload` and `createProgramWorkoutStartPayload` to encapsulate start-workout payload wiring. 
- Updated `useWorkoutScreen` to use `createBaseWorkoutStartPayload` and `createProgramWorkoutStartPayload` when dispatching `startWorkoutAction` instead of inlining identical object assembly. 
- Updated `useHomeDashboard` to use the same payload builders in `goToWorkout` so dashboard-initiated starts match the workout screen flow. 
- No functional changes to the start flow were introduced; imports were adjusted to reference the new helper module.

### Testing
- Ran `npm run build` successfully to verify the production build output. 
- Ran `npm run lint` sequentially after build, which completed with the existing warnings-only baseline (8 warnings) and no new errors. 
- Followed repository verification guidance by running build then lint in sequence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11499d9550832cba55c7ddd4074dfb)