### PR TITLE
Improve One-Rep-Max chart tap UX and persist analytics filters

### DIFF
--- a/src/domains/analytics/hooks/useOneRepMax.ts
+++ b/src/domains/analytics/hooks/useOneRepMax.ts
@@ -16,6 +16,8 @@ export interface UnifiedDataPoint {
 }
 
 const SELECTED_EXERCISE_STORAGE_KEY = 'selectedAnalyticsExerciseId';
+const SELECTED_TIME_RANGE_STORAGE_KEY = 'selectedAnalyticsTimeRange';
+const SELECTED_COMBINATION_STORAGE_KEY = 'selectedAnalyticsCombinationByExercise';
 
 const getCombinationKey = (
     variation?: string | null,
@@ -33,7 +35,13 @@ export const useOneRepMax = (userId: string | undefined, exercises: Exercise[]) 
     const [selectedExercise, setSelectedExercise] = useState<Exercise | null>(null);
     const [allCombinationKeys, setAllCombinationKeys] = useState<string[]>([]);
     const [activeCombinationKeys, setActiveCombinationKeys] = useState<string[]>([]);
-    const [selectedTimeRange, setSelectedTimeRange] = useState<TimeRange>('ALL');
+    const [selectedTimeRange, setSelectedTimeRange] = useState<TimeRange>(() => {
+        const storedRange = localStorage.getItem(SELECTED_TIME_RANGE_STORAGE_KEY);
+        const validRanges: TimeRange[] = ['1W', '1M', '3M', '6M', '1Y', 'ALL'];
+        return storedRange && validRanges.includes(storedRange as TimeRange)
+            ? (storedRange as TimeRange)
+            : 'ALL';
+    });
 
     // Initialize/Sync selected exercise from storage
     useEffect(() => {
@@ -51,6 +59,10 @@ export const useOneRepMax = (userId: string | undefined, exercises: Exercise[]) 
             localStorage.setItem(SELECTED_EXERCISE_STORAGE_KEY, selectedExercise.id);
         }
     }, [selectedExercise]);
+
+    useEffect(() => {
+        localStorage.setItem(SELECTED_TIME_RANGE_STORAGE_KEY, selectedTimeRange);
+    }, [selectedTimeRange]);
 
     // Fetch history
     const {
@@ -115,11 +127,28 @@ export const useOneRepMax = (userId: string | undefined, exercises: Exercise[]) 
                 }
             });
 
-            const newActiveKeys = mostFrequentKey ? [mostFrequentKey] : (sortedKeys.length > 0 ? [sortedKeys[0]] : []);
+            const storedCombinationsRaw = localStorage.getItem(SELECTED_COMBINATION_STORAGE_KEY);
+            const storedCombinations: Record<string, string> = storedCombinationsRaw ? JSON.parse(storedCombinationsRaw) : {};
+            const storedKeyForExercise = currentExerciseId ? storedCombinations[currentExerciseId] : undefined;
+
+            const preferredKey = storedKeyForExercise && sortedKeys.includes(storedKeyForExercise)
+                ? storedKeyForExercise
+                : mostFrequentKey;
+
+            const newActiveKeys = preferredKey ? [preferredKey] : (sortedKeys.length > 0 ? [sortedKeys[0]] : []);
             setActiveCombinationKeys(newActiveKeys);
             setLastInitializedExerciseId(currentExerciseId);
         }
     }, [maxE1RMHistory, selectedExercise?.id, allCombinationKeys, activeCombinationKeys, lastInitializedExerciseId]);
+
+    useEffect(() => {
+        if (!selectedExercise?.id || activeCombinationKeys.length === 0) return;
+
+        const storedCombinationsRaw = localStorage.getItem(SELECTED_COMBINATION_STORAGE_KEY);
+        const storedCombinations: Record<string, string> = storedCombinationsRaw ? JSON.parse(storedCombinationsRaw) : {};
+        storedCombinations[selectedExercise.id] = activeCombinationKeys[0];
+        localStorage.setItem(SELECTED_COMBINATION_STORAGE_KEY, JSON.stringify(storedCombinations));
+    }, [selectedExercise?.id, activeCombinationKeys]);
 
     // Transformation logic (moved from useMemo for clarity or kept as is)
     const chartContext = useMemo(() => {

--- a/src/domains/analytics/ui/OneRepMax.tsx
+++ b/src/domains/analytics/ui/OneRepMax.tsx
@@ -55,9 +55,16 @@ interface LockedTooltipState {
     payload?: ChartTooltipEntry[];
 }
 
-interface ChartPointerState {
-    activeLabel?: unknown;
-    activePayload?: unknown;
+interface SelectableDotProps {
+    cx?: number;
+    cy?: number;
+    stroke?: string;
+    fill?: string;
+    payload?: UnifiedDataPoint;
+    dataKey?: string;
+    name?: string;
+    value?: number | string | null;
+    onSelect?: (state: LockedTooltipState) => void;
 }
 
 interface CombinationLegendEntry {
@@ -140,6 +147,33 @@ const CustomTooltip = ({ active, payload, label }: ChartTooltipProps) => {
         );
     }
     return null;
+};
+
+const SelectableDot = ({ cx, cy, fill, payload, dataKey, name, value, onSelect }: SelectableDotProps) => {
+    if (cx == null || cy == null || value == null || !payload || !dataKey || !name) {
+        return null;
+    }
+
+    const numericValue = typeof value === 'number' ? value : Number(value);
+    if (Number.isNaN(numericValue)) {
+        return null;
+    }
+
+    return (
+        <g>
+            <circle cx={cx} cy={cy} r={14} fill="transparent" onClick={() => onSelect?.({
+                label: payload.workout_timestamp,
+                payload: [{
+                    dataKey,
+                    name,
+                    payload,
+                    value: numericValue,
+                    color: fill,
+                }],
+            })} />
+            <circle cx={cx} cy={cy} r={4.5} fill={fill} strokeWidth={0} />
+        </g>
+    );
 };
 
 interface AnalyticsExerciseSelectorProps {
@@ -287,13 +321,7 @@ const OneRepMaxView: React.FC<OneRepMaxProps> = ({
         setLockedTooltip(null);
     };
 
-    const captureTooltip = (state: ChartPointerState | null | undefined) => {
-        const label = typeof state?.activeLabel === "number" ? state.activeLabel : undefined;
-        const payload = state?.activePayload as ChartTooltipEntry[] | undefined;
-
-        if (label == null || !payload?.length) return;
-        setLockedTooltip({ label, payload });
-    };
+    const captureTooltip = (state: LockedTooltipState) => setLockedTooltip(state);
 
     const legendPayload = useMemo(() => {
         return allCombinationKeys.map((key, index) => {
@@ -384,8 +412,6 @@ const OneRepMaxView: React.FC<OneRepMaxProps> = ({
                                         <LineChart
                                             data={chartData}
                                             margin={{ top: 10, right: 4, left: 8, bottom: 5 }}
-                                            onClick={captureTooltip}
-                                            onTouchEnd={captureTooltip}
                                         >
                                             <CartesianGrid vertical={false} stroke="rgba(255,255,255,0.06)" />
                                             <XAxis
@@ -445,7 +471,13 @@ const OneRepMaxView: React.FC<OneRepMaxProps> = ({
                                                         name={displayName}
                                                         stroke={lineColors[index % lineColors.length]}
                                                         strokeWidth={2.6}
-                                                        dot={{ r: 4, fill: lineColors[index % lineColors.length], strokeWidth: 0 }}
+                                                        dot={(dotProps) => (
+                                                            <SelectableDot
+                                                                {...dotProps}
+                                                                fill={lineColors[index % lineColors.length]}
+                                                                onSelect={captureTooltip}
+                                                            />
+                                                        )}
                                                         activeDot={{ r: 9, fill: lineColors[index % lineColors.length], stroke: 'rgba(214, 223, 218, 0.22)', strokeWidth: 10 }}
                                                         connectNulls={true}
                                                     />


### PR DESCRIPTION
### Motivation
- Users on mobile found it difficult to lock tooltips because any tap on the chart (not just real points) could become the focus, making it hard to inspect actual data points. 
- The One-Rep-Max chart always defaulted to `ALL` timeframe and did not remember a user’s last equipment/variation choice, causing repetitive configuration when revisiting analytics. 
- Remembering timeframe and last-selected combination per exercise improves consistency and reduces repeated Supabase fetches for the same view.

### Description
- Persisted selected timeframe to localStorage with `SELECTED_TIME_RANGE_STORAGE_KEY` and initialize `selectedTimeRange` from that stored value in `src/domains/analytics/hooks/useOneRepMax.ts` so the chart reopens on the last-used range instead of always `ALL`.
- Added per-exercise combination persistence using `SELECTED_COMBINATION_STORAGE_KEY` and restored a stored variation/equipment key when initializing combinations, with a fallback to the most frequent combination discovered.
- Reworked point interaction in `src/domains/analytics/ui/OneRepMax.tsx` by adding a `SelectableDot` SVG wrapper that renders a small visual dot and a larger transparent hit target, and replaced the chart-wide click handlers so tooltips lock only when a real plotted point is selected.
- Kept visual `activeDot` behavior while increasing tap area for mobile and wired tooltip locking to the new dot-level handler rather than arbitrary chart positions.

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran `npm run lint` and lint completed with the existing baseline warnings only (no new lint errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1165cb6394832c8660e6ddccc56ede)