### PR TITLE
Improve 1RM chart point selection behavior

### DIFF
--- a/src/domains/analytics/ui/OneRepMax.tsx
+++ b/src/domains/analytics/ui/OneRepMax.tsx
@@ -159,18 +159,30 @@ const SelectableDot = ({ cx, cy, fill, payload, dataKey, name, value, onSelect }
         return null;
     }
 
+    const selectPoint = () => {
+        onSelect?.({
+            label: payload.workout_timestamp,
+            payload: [{
+                dataKey,
+                name,
+                payload,
+                value: numericValue,
+                color: fill,
+            }],
+        });
+    };
+
     return (
         <g>
-            <circle cx={cx} cy={cy} r={14} fill="transparent" onClick={() => onSelect?.({
-                label: payload.workout_timestamp,
-                payload: [{
-                    dataKey,
-                    name,
-                    payload,
-                    value: numericValue,
-                    color: fill,
-                }],
-            })} />
+            <circle
+                cx={cx}
+                cy={cy}
+                r={20}
+                fill="transparent"
+                style={{ cursor: 'pointer' }}
+                onMouseDown={selectPoint}
+                onTouchStart={selectPoint}
+            />
             <circle cx={cx} cy={cy} r={4.5} fill={fill} strokeWidth={0} />
         </g>
     );
@@ -434,10 +446,11 @@ const OneRepMaxView: React.FC<OneRepMaxProps> = ({
                                             />
                                             <Tooltip
                                                 content={<CustomTooltip />}
-                                                cursor={{ stroke: 'rgba(214, 223, 218, 0.18)', strokeWidth: 1 }}
-                                                active={lockedTooltip ? true : undefined}
+                                                cursor={lockedTooltip ? { stroke: 'rgba(214, 223, 218, 0.18)', strokeWidth: 1 } : false}
+                                                active={!!lockedTooltip}
                                                 label={lockedTooltip?.label}
                                                 payload={lockedTooltip?.payload}
+                                                trigger="click"
                                             />
                                             <Legend
                                                 onClick={(data) => {


### PR DESCRIPTION
### Motivation
- Prevent selecting/locking empty areas of the 1RM chart and make point selection respect actual plotted points rather than just an X-axis proximity. 
- Make tapping/selecting points more forgiving on mobile by increasing the hit area and supporting touch-specific events. 

### Description
- Tied point selection to the plotted dot by introducing a shared `selectPoint` handler on each rendered dot in `src/domains/analytics/ui/OneRepMax.tsx`. 
- Increased the transparent hit target radius from `14` to `20` and added `onMouseDown` and `onTouchStart` to unify mouse and touch interactions for more forgiving mobile selection. 
- Restricted tooltip activation to explicit data-point selection by changing the `Tooltip` to use a conditional `cursor` (`false` when no locked tooltip), `active={!!lockedTooltip}`, and `trigger="click"` so chart background clicks cannot lock/activate tooltips. 

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran `npm run lint` and it completed with the existing baseline warnings (8 warnings) and no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a117186ca88832c9ed83f92db634d2c)